### PR TITLE
Add chainId event

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ function MetamaskInpageProvider (connectionStream) {
   const self = this
   self.selectedAddress = undefined
   self.networkVersion = undefined
+  self.chainId = undefined
 
   // super constructor
   SafeEventEmitter.call(self)
@@ -46,6 +47,12 @@ function MetamaskInpageProvider (connectionStream) {
     if ('networkVersion' in state && state.networkVersion !== self.networkVersion) {
       self.networkVersion = state.networkVersion
       self.emit('networkChanged', state.networkVersion)
+    }
+
+    // Emit networkChanged event on network change
+    if ('chainId' in state && state.chainId !== self.chainId) {
+      self.chainId = state.chainId
+      self.emit('chainIdChanged', state.chainId)
     }
   })
 


### PR DESCRIPTION
resolves https://github.com/MetaMask/metamask-extension/issues/6885

The metamask inpage provider now emits a `'chainIdChanged'` event when the chain id changes in metamask state

Paired with: https://github.com/MetaMask/metamask-extension/pull/7110