### PR TITLE
Rename local ObservableStore variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const RpcEngine = require('json-rpc-engine')
 const createErrorMiddleware = require('./createErrorMiddleware')
 const createIdRemapMiddleware = require('json-rpc-engine/src/idRemapMiddleware')
 const createJsonRpcStream = require('json-rpc-middleware-stream')
-const LocalStorageStore = require('obs-store')
+const ObservableStore = require('obs-store')
 const asStream = require('obs-store/lib/asStream')
 const ObjectMultiplex = require('obj-multiplex')
 const util = require('util')
@@ -32,7 +32,7 @@ function MetamaskInpageProvider (connectionStream) {
   )
 
   // subscribe to metamask public config (one-way)
-  self.publicConfigStore = new LocalStorageStore({ storageKey: 'MetaMask-Config' })
+  self.publicConfigStore = new ObservableStore({ storageKey: 'MetaMask-Config' })
 
   // Emit events for some state changes
   self.publicConfigStore.subscribe(function (state) {


### PR DESCRIPTION
The previous local variable name 'LocalStorageStore' wrongly implied that `obs-store/lib/localStorage` was being used.