### PR TITLE
Update `accountsChanged` event when logged out

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ function MetamaskInpageProvider (connectionStream) {
     // Emit accountsChanged event on account change
     if ('selectedAddress' in state && state.selectedAddress !== self.selectedAddress) {
       self.selectedAddress = state.selectedAddress
-      self.emit('accountsChanged', [self.selectedAddress])
+      const accounts = state.selectedAddress ?
+        [state.selectedAddress] :
+        []
+      self.emit('accountsChanged', accounts)
     }
 
     // Emit networkChanged event on network change


### PR DESCRIPTION
The `accountsChanged` event would previously return `[undefined]` upon logout (i.e. when `selectedAddress` was undefined).

Instead an empty array is now returned if the user is not logged in. This seems more semantically correct, and is more in-line with EIP-1193, which states that the event should emit an array of strings.