### PR TITLE
Send site metadata on dom content loaded to ensure metadata availability

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const {
 } = require('./src/utils')
 
 // resolve response.result, reject errors
-const rpcPromiseCallback = (resolve, reject) => (error, response) => {
+const getRpcPromiseCallback = (resolve, reject) => (error, response) => {
   error || response.error
     ? reject(error || response.error)
     : Array.isArray(response)
@@ -151,9 +151,11 @@ function MetamaskInpageProvider (connectionStream) {
   })
 
   // send website metadata
-  window.addEventListener('DOMContentLoaded', () => {
+  const domContentLoadedHandler = () => {
     sendSiteMetadata(this._rpcEngine)
-  })
+    window.removeEventListener('DOMContentLoaded', domContentLoadedHandler)
+  }
+  window.addEventListener('DOMContentLoaded', domContentLoadedHandler)
 
   // indicate that we've connected, for EIP-1193 compliance
   setTimeout(() => this.emit('connect'))
@@ -266,7 +268,7 @@ MetamaskInpageProvider.prototype.send = function (methodOrPayload, params) {
     try {
       this._sendAsync(
         payload,
-        rpcPromiseCallback(resolve, reject),
+        getRpcPromiseCallback(resolve, reject),
       )
     } catch (error) {
       reject(error)
@@ -290,7 +292,7 @@ MetamaskInpageProvider.prototype.enable = function () {
     try {
       this._sendAsync(
         { method: 'eth_requestAccounts', params: [] },
-        rpcPromiseCallback(resolve, reject),
+        getRpcPromiseCallback(resolve, reject),
       )
     } catch (error) {
       reject(error)
@@ -487,7 +489,7 @@ function getExperimentalApi (instance) {
           try {
             instance._sendAsync(
               requests,
-              rpcPromiseCallback(resolve, reject),
+              getRpcPromiseCallback(resolve, reject),
             )
           } catch (error) {
             reject(error)

--- a/index.js
+++ b/index.js
@@ -151,7 +151,9 @@ function MetamaskInpageProvider (connectionStream) {
   })
 
   // send website metadata
-  sendSiteMetadata(this._rpcEngine)
+  window.addEventListener('DOMContentLoaded', () => {
+    sendSiteMetadata(this._rpcEngine)
+  })
 
   // indicate that we've connected, for EIP-1193 compliance
   setTimeout(() => this.emit('connect'))

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,7 +1,8 @@
 module.exports = {
   errors: {
-    invalidParams: () => `Invalid request parameters. Please use ethereum.send(method: string, params: Array<any>). For more details, see: https://eips.ethereum.org/EIPS/eip-1193`,
-    unsupportedSync: (method) => `The MetaMask Web3 object does not support synchronous methods like ${method} without a callback parameter.`, // TODO:deprecate:2020-01-13
+    invalidParams: () => `MetaMask: Invalid request parameters. Please use ethereum.send(method: string, params: Array<any>). For more details, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    sendSiteMetadata: () => `MetaMask: Failed to send site metadata. This is an internal error, please report this bug.`,
+    unsupportedSync: (method) => `MetaMask: The MetaMask Web3 object does not support synchronous methods like ${method} without a callback parameter.`, // TODO:deprecate:2020-01-13
   },
   warnings: {
     // TODO:deprecate:2020-01-13

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -1,4 +1,6 @@
 
+const { errors } = require ('./messages')
+
 module.exports = {
   sendSiteMetadata,
 }
@@ -9,6 +11,7 @@ module.exports = {
 async function sendSiteMetadata (engine) {
   try {
     const domainMetadata = await getSiteMetadata()
+    // call engine.handle directly to avoid normal RPC request handling
     engine.handle(
       {
         method: 'wallet_sendDomainMetadata',
@@ -18,7 +21,7 @@ async function sendSiteMetadata (engine) {
     )
   } catch (error) {
     console.error({
-      message: 'Failed to send site metadata',
+      message: errors.sendSiteMetadata(),
       originalError: error,
     })
   }


### PR DESCRIPTION
This PR fixes an issue with the retrieval of site metadata. Prior to this PR, it seems that `document.title` is undefined at the time that `sendSiteMetadata` is called. By only calling `sendSiteMetaData` when the dom content is ready (on a `DOMContentLoaded`), we ensure that (at least) `document.title` will be defined if available.