### PR TITLE
More validation in _sendAsync; optional metadata sending

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,6 +241,8 @@ MetamaskInpageProvider.prototype.send = function (methodOrPayload, params) {
   ) {
 
     // wrap params in array out of kindness
+    // params have to be an array per EIP 1193, even though JSON RPC
+    // allows objects
     if (params === undefined) {
       params = []
     } else if (!Array.isArray(params)) {
@@ -253,12 +255,12 @@ MetamaskInpageProvider.prototype.send = function (methodOrPayload, params) {
     }
   }
 
-  // typecheck payload and payload.method
+  // typecheck payload, payload.method, and payload.params
   if (
-    Array.isArray(payload) ||
-    typeof params === 'function' ||
     typeof payload !== 'object' ||
-    typeof payload.method !== 'string'
+    Array.isArray(payload) ||
+    !Array.isArray(params) ||
+    !payload.method || typeof payload.method !== 'string'
   ) {
     throw ethErrors.rpc.invalidRequest({
       message: messages.errors.invalidParams(),
@@ -375,24 +377,8 @@ MetamaskInpageProvider.prototype._sendAsync = function (payload, userCallback, i
 
   if (!Array.isArray(payload)) {
 
-    if (!payload.method || typeof payload.method !== 'string') {
-      throw ethErrors.rpc.invalidRequest({
-        message: `The request 'method' must be a non-empty string.`,
-        data: payload,
-      })
-    }
-
     if (!payload.jsonrpc) {
       payload.jsonrpc = '2.0'
-    }
-
-    if (!payload.params) {
-      payload.params = []
-    } else if (!Array.isArray(payload.params)) {
-      throw ethErrors.rpc.invalidRequest({
-        message: `The request 'params' must be an array.`,
-        data: payload,
-      })
     }
 
     if (

--- a/index.js
+++ b/index.js
@@ -255,12 +255,11 @@ MetamaskInpageProvider.prototype.send = function (methodOrPayload, params) {
     }
   }
 
-  // typecheck payload, payload.method, and payload.params
+  // typecheck payload and payload.params
   if (
     typeof payload !== 'object' ||
     Array.isArray(payload) ||
-    !Array.isArray(params) ||
-    !payload.method || typeof payload.method !== 'string'
+    !Array.isArray(params)
   ) {
     throw ethErrors.rpc.invalidRequest({
       message: messages.errors.invalidParams(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-inpage-provider",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "An ethereum provider that connects over a WebExtension port.",
   "main": "index.js",
   "scripts": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,6 @@
 
 const log = require('loglevel')
-const { serializeError } = require('eth-json-rpc-errors')
+const { ethErrors, serializeError } = require('eth-json-rpc-errors')
 const EventEmitter = require('events')
 const SafeEventEmitter = require('safe-event-emitter')
 
@@ -17,7 +17,16 @@ const SafeEventEmitter = require('safe-event-emitter')
  * @returns {Function} json-rpc-engine middleware function
  */
 function createErrorMiddleware () {
-  return (_req, res, next) => {
+  return (req, res, next) => {
+
+    // json-rpc-engine will terminate the request when it notices this error
+    if (!req.method || typeof req.method !== 'string') {
+      res.error = ethErrors.rpc.invalidRequest({
+        message: `The request 'method' must be a non-empty string.`,
+        data: req,
+      })
+    }
+
     next(done => {
       const { error } = res
       if (!error) {


### PR DESCRIPTION
### Main

This PR typechecks `payload.method` in the inpage provider's error middleware. I originally did this in `_sendAsync`, throwing an error on failure. To prevent unexpected errors to be thrown in consumer code, I moved the typecheck to the middleware so that the error appears on the RPC response object, as it would have previously.

I also decided against typechecking or setting `payload.params` in `_sendAsync`. `params` are an array in Ethereum JSON RPC by convention only; JSON RPC 2.0 allows `params` to be an array, object, or omitted. In other words, the receiving end should handle it. I implemented a temporary fix in Mobile for now, and will remove `web3-provider-engine` later.

All remaining thrown errors in this module either cause Promise rejections or have always been there.

### Misc

These changes also allow the consumer of this module to specify whether `wallet_sendDomainMetadata` should be sent, by means of a boolean argument to the constructor. This will be useful for both plugins and Mobile, for instance.