### PR TITLE
Fix faulty null checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -218,6 +218,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // construct payload object
     let payload
     if (
+      methodOrPayload &&
       typeof methodOrPayload === 'object' &&
       !Array.isArray(methodOrPayload)
     ) {
@@ -262,6 +263,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
     // typecheck payload and payload.params
     if (
+      !payload ||
       typeof payload !== 'object' ||
       Array.isArray(payload) ||
       !Array.isArray(params)
@@ -459,7 +461,11 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // handle web3
     if (this._web3Ref) {
       this._web3Ref.defaultAccount = this.selectedAddress
-    } else if (window.web3 && typeof window.web3.eth === 'object') {
+    } else if (
+      window.web3 &&
+      window.web3.eth &&
+      typeof window.web3.eth === 'object'
+    ) {
       window.web3.eth.defaultAccount = this.selectedAddress
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-inpage-provider",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "An ethereum provider that connects over a WebExtension port.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/MetaMask/metamask-inpage-provider#readme",
   "dependencies": {
-    "eth-json-rpc-errors": "^2.0.1",
+    "eth-json-rpc-errors": "^2.0.2",
     "fast-deep-equal": "^2.0.1",
     "json-rpc-engine": "^5.1.5",
     "json-rpc-middleware-stream": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -362,10 +362,10 @@ eth-json-rpc-errors@^2.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-errors@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.1.tgz#e7a4c4e3c76913dff26dbc021966c72b2822e0f2"
-  integrity sha512-ldF9fdzkdHAgTWmqh/bgHi7uH+8icAyjcEdFOBGD32zTWd7J66VDo0rBaiaQPowXitiyAcs1R23Mje1gkdIofA==
+eth-json-rpc-errors@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
+  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
   dependencies:
     fast-safe-stringify "^2.0.6"
 


### PR DESCRIPTION
- **Includes patch version bump**
- **PENDING**
  - [x] https://github.com/MetaMask/eth-json-rpc-errors/pull/5
- For typechecks of the form `/typeof .+ (===|!==) 'object'/`, adds a check if the tested variable is truthy or falsy as appropriate.