### PR TITLE
call _handleAccountsChange when selectedAddress changed in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,11 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         this.emit('chainIdChanged', this.chainId) // TODO:deprecate:2020-Q1
       }
 
+      // Emit accountsChanged event on account change
+      if ('selectedAddress' in state && state.selectedAddress !== this.selectedAddress) {
+        this._handleAccountsChanged([state.selectedAddress])
+      }
+
       // Emit networkChanged event on network change
       if ('networkVersion' in state && state.networkVersion !== this.networkVersion) {
         this.networkVersion = state.networkVersion


### PR DESCRIPTION
When I used the Metamask Inpage Provider in my chrome extension, it didn't get any wallet_accountsChanged event. Also it can be useful if the selectedAddress changes in ConfigStore, can be handled correctly by calling the  _handleAccountsChange method. 