### PR TITLE
Implement new 1193 spec, fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.log

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -220,6 +220,8 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   //====================
 
   /**
+   * Experimental. The signature of this method may change without warning, pending EIP 1193.
+   *
    * Submits an RPC request to MetaMask for the given method, with the given params.
    * Resolves with the result of the method call, or rejects on error.
    *

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -269,8 +269,16 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   /**
    * We override the following event methods so that we can warn consumers
    * about deprecated events:
-   *   on, once
+   *   addListener, on, once, prependListener, prependOnceListener
    */
+
+  /**
+   * @inheritdoc
+   */
+  addListener (eventName, listener) {
+    this._warnOfDeprecation(eventName)
+    return super.addListener(eventName, listener)
+  }
 
   /**
    * @inheritdoc
@@ -286,6 +294,22 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   once (eventName, listener) {
     this._warnOfDeprecation(eventName)
     return super.once(eventName, listener)
+  }
+
+  /**
+   * @inheritdoc
+   */
+  prependListener (eventName, listener) {
+    this._warnOfDeprecation(eventName)
+    return super.prependListener(eventName, listener)
+  }
+
+  /**
+   * @inheritdoc
+   */
+  prependOnceListener (eventName, listener) {
+    this._warnOfDeprecation(eventName)
+    return super.prependOnceListener(eventName, listener)
   }
 
   //====================

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -53,7 +53,6 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         experimentalMethods: false,
         isConnected: false,
         send: false,
-        // sendAsync: false,
         // events
         events: {
           chainIdChanged: false,
@@ -255,6 +254,16 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         getRpcPromiseCallback(resolve, reject),
       )
     })
+  }
+
+  /**
+   * Submit a JSON-RPC request object and a callback to make an RPC method call.
+   *
+   * @param {Object} payload - The RPC request object.
+   * @param {Function} callback - The callback function.
+   */
+  sendAsync (payload, cb) {
+    this._rpcRequest(payload, cb)
   }
 
   /**
@@ -561,21 +570,6 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       return this._rpcRequest(methodOrPayload, callbackOrArgs)
     }
     return this._sendSync(methodOrPayload)
-  }
-
-  /**
-   * Submit a JSON-RPC request object and a callback to make an RPC method call.
-   *
-   * @param {Object} payload - The RPC request object.
-   * @param {Function} callback - The callback function.
-   */
-  sendAsync (payload, cb) {
-
-    // if (!this._state.sentWarnings.sendAsync) {
-    //   log.warn(messages.warnings.sendAsyncDeprecation)
-    //   this._state.sentWarnings.sendAsync = true
-    // }
-    this._rpcRequest(payload, cb)
   }
 
   /**

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -30,7 +30,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
    */
   constructor (
     connectionStream,
-    { shouldSendMetadata = true, maxEventListeners = 100 },
+    { shouldSendMetadata = true, maxEventListeners = 100 } = {},
   ) {
 
     if (

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -80,7 +80,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // bind functions (to prevent e.g. web3@1.x from making unbound calls)
     this._handleAccountsChanged = this._handleAccountsChanged.bind(this)
     this._handleDisconnect = this._handleDisconnect.bind(this)
-    this._legacySend = this._legacySend.bind(this)
+    this._sendSync = this._sendSync.bind(this)
     this._rpcRequest = this._rpcRequest.bind(this)
     this._warnOfDeprecation = this._warnOfDeprecation.bind(this)
     this.enable = this.enable.bind(this)
@@ -560,7 +560,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     ) {
       return this._rpcRequest(methodOrPayload, callbackOrArgs)
     }
-    return this._legacySend(methodOrPayload)
+    return this._sendSync(methodOrPayload)
   }
 
   /**
@@ -580,9 +580,9 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   /**
    * DEPRECATED
-   * Internal backwards compatibility method.
+   * Internal backwards compatibility method, used in send.
    */
-  _legacySend (payload) {
+  _sendSync (payload) {
 
     let result
     switch (payload.method) {

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -424,8 +424,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         /**
          * Make a batch RPC request.
          */
-        // eslint-disable-next-line require-await
-        batchRequest: async (requests) => {
+        requestBatch: async (requests) => {
 
           if (!Array.isArray(requests)) {
             throw ethErrors.rpc.invalidRequest({

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -53,7 +53,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         experimentalMethods: false,
         isConnected: false,
         send: false,
-        sendAsync: false,
+        // sendAsync: false,
         // events
         events: {
           chainIdChanged: false,
@@ -562,19 +562,17 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
-   * DEPRECATED
-   * Backwards compatibility; ethereum.request() with JSON-RPC request object
-   * and a callback.
+   * Submit a JSON-RPC request object and a callback to make an RPC method call.
    *
    * @param {Object} payload - The RPC request object.
    * @param {Function} callback - The callback function.
    */
   sendAsync (payload, cb) {
 
-    if (!this._state.sentWarnings.sendAsync) {
-      log.warn(messages.warnings.sendAsyncDeprecation)
-      this._state.sentWarnings.sendAsync = true
-    }
+    // if (!this._state.sentWarnings.sendAsync) {
+    //   log.warn(messages.warnings.sendAsyncDeprecation)
+    //   this._state.sentWarnings.sendAsync = true
+    // }
     this._rpcRequest(payload, cb)
   }
 

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -558,7 +558,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
-   * DEPRECATED
+   * DEPRECATED.
    * Sends an RPC request to MetaMask.
    * Many different return types, which is why this method should not be used.
    *
@@ -597,7 +597,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
-   * DEPRECATED
+   * DEPRECATED.
    * Internal backwards compatibility method, used in send.
    */
   _sendSync (payload) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -8,9 +8,9 @@ module.exports = {
     // TODO:deprecation:remove
     autoReloadDeprecation: `MetaMask: MetaMask will soon stop reloading pages on network change.\nFor more information, see: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44 \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.autorefreshonnetworkchange`,
     // deprecated methods
-    enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and will be removed in the future. Please use "ethereum.request({ method: 'eth_requestAccounts' })" instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
+    enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and will be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
     isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and will be removed in the future. Please listen for the relevant events instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
-    sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and will be removed in the future. Please use 'ethereum.request(method: string, params: Array<any> | Object)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and will be removed in the future. Please use 'ethereum.sendAsync(...)' or 'ethereum.request(...)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     // deprecated events
     events: {
       chainIdChanged: `MetaMask: The event 'chainIdChanged' is deprecated and will be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,

--- a/src/messages.js
+++ b/src/messages.js
@@ -11,7 +11,6 @@ module.exports = {
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and will be removed in the future. Please use "ethereum.request({ method: 'eth_requestAccounts' })" instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
     isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and will be removed in the future. Please listen for the relevant events instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and will be removed in the future. Please use 'ethereum.request(method: string, params: Array<any> | Object)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
-    sendAsyncDeprecation: `MetaMask: 'ethereum.sendAsync(...)' is deprecated and will be removed in the future. Please use 'ethereum.request(method: string, params: Array<any> | Object)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     // deprecated events
     events: {
       chainIdChanged: `MetaMask: The event 'chainIdChanged' is deprecated and will be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,16 +1,24 @@
 module.exports = {
   errors: {
-    invalidParams: () => `MetaMask: Invalid request parameters. Please use ethereum.sendAsync(request: Object, callback: Function).`,
+    disconnected: () => `MetaMask: Lost connection to MetaMask background process.`,
     sendSiteMetadata: () => `MetaMask: Failed to send site metadata. This is an internal error, please report this bug.`,
     unsupportedSync: (method) => `MetaMask: The MetaMask Web3 object does not support synchronous methods like ${method} without a callback parameter.`, // TODO:deprecation:remove
   },
   warnings: {
     // TODO:deprecation:remove
-    autoReloadDeprecation: `MetaMask: MetaMask will stop reloading pages on network change in Q2 2020. For more information, see: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44 \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.autorefreshonnetworkchange`,
-    // deprecated stuff yet to be scheduled for removal
-    enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use "ethereum.sendAsync({ method: 'eth_requestAccounts' })" instead.`,
-    isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and may be removed in the future. Please listen for the relevant events instead. For more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
-    sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and may be removed in the future. Please use 'ethereum.sendAsync({ method: string, params: Array<any> | Object }, callback: Function)' instead.`,
+    autoReloadDeprecation: `MetaMask: MetaMask will soon stop reloading pages on network change.\nFor more information, see: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44 \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.autorefreshonnetworkchange`,
+    // deprecated methods
+    enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and will be removed in the future. Please use "ethereum.request({ method: 'eth_requestAccounts' })" instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
+    isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and will be removed in the future. Please listen for the relevant events instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and will be removed in the future. Please use 'ethereum.request(method: string, params: Array<any> | Object)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    sendAsyncDeprecation: `MetaMask: 'ethereum.sendAsync(...)' is deprecated and will be removed in the future. Please use 'ethereum.request(method: string, params: Array<any> | Object)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    // deprecated events
+    events: {
+      chainIdChanged: `MetaMask: The event 'chainIdChanged' is deprecated and will be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+      close: `MetaMask: The event 'close' is deprecated and will be removed in the future. Please use 'disconnect' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+      networkChanged: `MetaMask: The event 'networkChanged' is deprecated and will be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+      notification: `MetaMask: The event 'notification' is deprecated and will be removed in the future. Please use 'message' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+    },
     // misc
     experimentalMethods: `MetaMask: 'ethereum._metamask' exposes non-standard, experimental methods. They may be removed or changed without warning.`,
   },


### PR DESCRIPTION
Implements [the new EIP 1193 specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md).

- Adds
  - Methods
    - `request(args)`, the only future-proof way of making RPC requests
  - Events
    - `message`, a replacement for `notification`
    - `disconnect`, a replacement for `close`
- Deprecates (in addition to existing deprecations, with warning messages)
  - Events
    - `chainIdChanged`
    - `close`
    - `networkChanged`
    - `notification`
- Changes
  - Experimental methods:
    - `sendBatch` -> `requestBatch`