### PR TITLE
Add global initialization event

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,8 @@
-module.exports = require('./src/MetamaskInpageProvider')
+const MetamaskInpageProvider = require('./src/MetamaskInpageProvider')
+const { initProvider, setGlobalProvider } = require('./src/initProvider')
+
+module.exports = {
+  MetamaskInpageProvider,
+  initProvider,
+  setGlobalProvider,
+}

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -43,7 +43,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
     this.isMetaMask = true
 
-    this.setMaxEventListeners(maxEventListeners)
+    this.setMaxListeners(maxEventListeners)
 
     // private state, kept here in part for use in the _metamask proxy
     this._state = {

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -22,11 +22,28 @@ const {
 
 module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
-  constructor (connectionStream, shouldSendMetadata = true) {
+  /**
+   * @param {Object} connectionStream - A Node.js stream
+   * @param {Object} opts - An options bag
+   * @param {number} opts.maxEventListeners - The maximum number of event listeners
+   * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata
+   */
+  constructor (
+    connectionStream,
+    { shouldSendMetadata = true, maxEventListeners = 100 },
+  ) {
+
+    if (
+      typeof shouldSendMetadata !== 'boolean' || typeof maxEventListeners !== 'number'
+    ) {
+      throw new Error('Invalid options.')
+    }
 
     super()
 
     this.isMetaMask = true
+
+    this.setMaxEventListeners(maxEventListeners)
 
     // private state, kept here in part for use in the _metamask proxy
     this._state = {

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -1,30 +1,22 @@
 const MetamaskInpageProvider = require('./MetamaskInpageProvider')
 
-// Work around for web3@1.0 deleting the bound `sendAsync` but not the unbound
-// `sendAsync` method on the prototype, causing `this` reference issues
-const defaultProxyHandler = {
-  // straight up lie that we deleted the property so that it doesnt
-  // throw an error in strict mode
-  deleteProperty: () => true,
-}
-
 /**
    * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
    *
    * @param {Object} opts - An options bag.
    * @param {Object} opts.connectionStream - A Node.js stream.
    * @param {number} opts.maxEventListeners - The maximum number of event listeners.
+   * @param {boolean} opts.preventPropertyDeletion - Whether to wrap the provider in a proxy that prevents property deletion.
    * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata.
-   * @param {Object} opts.proxyHandler - A proxy handler object. The provider is proxied if present.
-   * @param {boolean} opts.shouldSet - Whether the provider should be set as window.ethereum
+   * @param {boolean} opts.shouldSetOnWindow - Whether the provider should be set as window.ethereum
    * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
    */
 function initProvider ({
   connectionStream,
-  shouldSendMetadata = true,
   maxEventListeners = 100,
-  proxyHandler = defaultProxyHandler,
-  shouldSet = true,
+  preventPropertyDeletion = true,
+  shouldSendMetadata = true,
+  shouldSetOnWindow = true,
 }) {
 
   if (!connectionStream) {
@@ -35,11 +27,15 @@ function initProvider ({
     connectionStream, { shouldSendMetadata, maxEventListeners },
   )
 
-  if (proxyHandler) {
-    provider = new Proxy(provider, proxyHandler)
+  if (preventPropertyDeletion) {
+    // Workaround for web3@1.0 deleting the bound `sendAsync` but not the unbound
+    // `sendAsync` method on the prototype, causing `this` reference issues
+    provider = new Proxy(provider, {
+      deleteProperty: () => true,
+    })
   }
 
-  if (shouldSet) {
+  if (shouldSetOnWindow) {
     setGlobalProvider(provider)
   }
 

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -1,5 +1,13 @@
 const MetamaskInpageProvider = require('./MetamaskInpageProvider')
 
+// Work around for web3@1.0 deleting the bound `sendAsync` but not the unbound
+// `sendAsync` method on the prototype, causing `this` reference issues
+const defaultProxyHandler = {
+  // straight up lie that we deleted the property so that it doesnt
+  // throw an error in strict mode
+  deleteProperty: () => true,
+}
+
 /**
    * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
    *
@@ -15,7 +23,7 @@ function initProvider ({
   connectionStream,
   shouldSendMetadata = true,
   maxEventListeners = 100,
-  proxyHandler,
+  proxyHandler = defaultProxyHandler,
   shouldSet = true,
 }) {
 

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -1,0 +1,55 @@
+const MetamaskInpageProvider = require('./MetamaskInpageProvider')
+
+/**
+   * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
+   *
+   * @param {Object} opts - An options bag.
+   * @param {Object} opts.connectionStream - A Node.js stream.
+   * @param {number} opts.maxEventListeners - The maximum number of event listeners.
+   * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata.
+   * @param {Object} opts.proxyHandler - A proxy handler object. The provider is proxied if present.
+   * @param {boolean} opts.shouldSet - Whether the provider should be set as window.ethereum
+   * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
+   */
+function initProvider ({
+  connectionStream,
+  shouldSendMetadata = true,
+  maxEventListeners = 100,
+  proxyHandler,
+  shouldSet = true,
+}) {
+
+  if (!connectionStream) {
+    throw new Error('Must provide a connection stream.')
+  }
+
+  let provider = new MetamaskInpageProvider(
+    connectionStream, { shouldSendMetadata, maxEventListeners },
+  )
+
+  if (proxyHandler) {
+    provider = new Proxy(provider, proxyHandler)
+  }
+
+  if (shouldSet) {
+    setGlobalProvider(provider)
+  }
+
+  return provider
+}
+
+/**
+ * Sets the given provider instance as window.ethereum and dispatches the
+ * 'ethereum#initialized' event on window.
+ *
+ * @param {MetamaskInpageProvider} providerInstance - The provider instance.
+ */
+function setGlobalProvider (providerInstance) {
+  window.ethereum = providerInstance
+  window.dispatchEvent(new Event('ethereum#initialized'))
+}
+
+module.exports = {
+  initProvider,
+  setGlobalProvider,
+}


### PR DESCRIPTION
- Adds a global initialization event for asynchronous injection: `ethereum#initialized`
- Restructures the repo and the module's exports
  - Adds exported initialization utility methods
  - Compare work with [the extension's `inpage.js`](https://github.com/MetaMask/metamask-extension/blob/develop/app/scripts/inpage.js)