### PR TITLE
Prevent some property overwrites in proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ initProvider({
 
 const { ethereum } = window
 ```
+
+### Do Not Modify the Provider
+
+The Provider object should not be mutated by consumers under any circumstances.
+The maintainers of this package will neither fix nor take responsbility for bugs caused by third parties mutating the provider object.

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -632,12 +632,4 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       result,
     }
   }
-
-  /**
-   * DEPRECATED.
-   * For MetaMask injected web3.
-   */
-  _setWeb3Ref (web3Ref) {
-    this._web3Ref = web3Ref
-  }
 }

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -632,4 +632,12 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       result,
     }
   }
+
+  /**
+   * DEPRECATED.
+   * For MetaMask injected web3.
+   */
+  _setWeb3Ref (web3Ref) {
+    this._web3Ref = web3Ref
+  }
 }

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -18,7 +18,7 @@ function initProvider ({
   protectProperties = true,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
-}) {
+} = {}) {
 
   const PROTECTED_PROPERTIES = new Set([
     '_handleAccountsChanged',

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -20,15 +20,9 @@ function initProvider ({
   shouldSetOnWindow = true,
 } = {}) {
 
+  // public, non-deprecated properties
   const PROTECTED_PROPERTIES = new Set([
-    '_handleAccountsChanged',
-    '_handleDisconnect',
     '_metamask',
-    '_publicConfigStore',
-    '_rpcEngine',
-    '_rpcRequest',
-    '_sendSync',
-    '_state',
     'isMetaMask',
     'request',
   ])

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -46,13 +46,13 @@ function initProvider ({
     // Some libraries, e.g. web3@1.x, mess with our API.
     provider = new Proxy(provider, {
       deleteProperty: () => true,
-      set: (_provider, prop, _value) => {
+      set: (target, prop, value, receiver) => {
         if (PROTECTED_PROPERTIES.has(prop)) {
           throw new Error(`MetaMask: Overwriting 'ethereum.${prop}' is forbidden.`)
         } else {
-          return Reflect.set(...arguments)
+          return Reflect.set(target, prop, value, receiver)
         }
-      }
+      },
     })
   }
 

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -31,7 +31,6 @@ function initProvider ({
     '_state',
     'isMetaMask',
     'request',
-    'sendAsync',
   ])
 
   if (!connectionStream) {


### PR DESCRIPTION
This prevents some internal state properties and the non-deprecated parts of our API from being overwritten, if the Provider is proxy-wrapped.

It won't solve existing overwrites of e.g. `ethereum.send`, but we don't care about that method anyway, and in this way, we won't break existing dapps.