### PR TITLE
Fix send method return value

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -581,7 +581,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         try {
           this._rpcRequest(
             { method: methodOrPayload, params: callbackOrArgs },
-            getRpcPromiseCallback(resolve, reject, true),
+            getRpcPromiseCallback(resolve, reject, false),
           )
         } catch (error) {
           reject(error)

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -581,7 +581,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         try {
           this._rpcRequest(
             { method: methodOrPayload, params: callbackOrArgs },
-            getRpcPromiseCallback(resolve, reject),
+            getRpcPromiseCallback(resolve, reject, true),
           )
         } catch (error) {
           reject(error)

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,12 +34,12 @@ function createErrorMiddleware () {
   }
 }
 
-// resolve response.result, reject errors
-const getRpcPromiseCallback = (resolve, reject) => (error, response) => {
+// resolve response.result or response, reject errors
+const getRpcPromiseCallback = (resolve, reject, resolveResponse = false) => (error, response) => {
   if (error || response.error) {
     reject(error || response.error)
   } else {
-    Array.isArray(response)
+    resolveResponse || Array.isArray(response)
       ? resolve(response)
       : resolve(response.result)
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,11 +35,11 @@ function createErrorMiddleware () {
 }
 
 // resolve response.result or response, reject errors
-const getRpcPromiseCallback = (resolve, reject, resolveResponse = false) => (error, response) => {
+const getRpcPromiseCallback = (resolve, reject, unwrapResult = true) => (error, response) => {
   if (error || response.error) {
     reject(error || response.error)
   } else {
-    resolveResponse || Array.isArray(response)
+    !unwrapResult || Array.isArray(response)
       ? resolve(response)
       : resolve(response.result)
   }


### PR DESCRIPTION
In the production extension, `ethereum.send(method: string, params?: Array<any>)` returns the entire JSON RPC `response` object, not `response.result`.

We want to keep this to avoid breaking `send`, so this has now been fixed.