### PR TITLE
Replace public config stream with RPC methods/notifications

### DIFF
--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -2,12 +2,12 @@ const pump = require('pump')
 const RpcEngine = require('json-rpc-engine')
 const createIdRemapMiddleware = require('json-rpc-engine/src/idRemapMiddleware')
 const createJsonRpcStream = require('json-rpc-middleware-stream')
+const ObservableStore = require('obs-store')
 const ObjectMultiplex = require('obj-multiplex')
 const SafeEventEmitter = require('safe-event-emitter')
 const dequal = require('fast-deep-equal')
 const { ethErrors } = require('eth-rpc-errors')
 const { duplex: isDuplex } = require('is-stream')
-const ObservableStore = require('obs-store')
 
 const messages = require('./messages')
 const { sendSiteMetadata } = require('./siteMetadata')
@@ -93,17 +93,10 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
         autoRefresh: false,
         publicConfigStore: false,
       },
-      isConnected: null,
       accounts: null,
+      isConnected: false,
       isUnlocked: false,
     }
-
-    // TODO:deprecation:remove
-    this._publicConfigStore = new ObservableStore({
-      isUnlocked: this._state.isUnlocked,
-      networkVersion: this._state.networkVersion,
-      chainId: this._state.chainId,
-    })
 
     this._metamask = this._getExperimentalApi()
 
@@ -111,6 +104,13 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
     this.selectedAddress = null
     this.networkVersion = null
     this.chainId = null
+
+    // TODO:deprecation:remove
+    this._publicConfigStore = new ObservableStore({
+      isUnlocked: this._state.isUnlocked,
+      networkVersion: this.networkVersion,
+      chainId: this.chainId,
+    })
 
     // bind functions (to prevent e.g. web3@1.x from making unbound calls)
     this._handleAccountsChanged = this._handleAccountsChanged.bind(this)

--- a/test/MetaMaskInpageProvider.misc.test.js
+++ b/test/MetaMaskInpageProvider.misc.test.js
@@ -152,7 +152,7 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
 
       expect(
         provider.isConnected(),
-      ).toBeUndefined()
+      ).toBeNull()
 
       provider._state.isConnected = true
 

--- a/test/MetaMaskInpageProvider.misc.test.js
+++ b/test/MetaMaskInpageProvider.misc.test.js
@@ -152,7 +152,7 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
 
       expect(
         provider.isConnected(),
-      ).toBeNull()
+      ).toBe(false)
 
       provider._state.isConnected = true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3487,7 +3487,20 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@~2.3.6:
+readable-stream@^2.2.2, readable-stream@~2.3.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^2.3.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==


### PR DESCRIPTION
- Deletes the public config stream, keeps `_publicConfigStore` and `publicConfigStore` getter
  - `_publicConfigStore` should behave exactly as before, since the new notification handlers update its state
- Gets state previously received through public config stream with RPC method and notifications
  - New RPC Methods
    - `wallet_getProviderState`
  - New RPC Notifications
    - `wallet_unlockStateChanged`
    - `wallet_chainChanged`

Corresponding PR in extension: https://github.com/MetaMask/metamask-extension/pull/8640