### PR TITLE
Modify property overwrite protection

### DIFF
--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -20,9 +20,11 @@ function initProvider ({
   shouldSetOnWindow = true,
 } = {}) {
 
-  // public properties new as of v5.0.0
+  // new properties as of v5.0.0
   const PROTECTED_PROPERTIES = new Set([
     'request',
+    '_rpcRequest',
+    '_rpcEngine',
   ])
 
   if (!connectionStream) {

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -20,10 +20,8 @@ function initProvider ({
   shouldSetOnWindow = true,
 } = {}) {
 
-  // public, non-deprecated properties
+  // public properties new as of v5.0.0
   const PROTECTED_PROPERTIES = new Set([
-    '_metamask',
-    'isMetaMask',
     'request',
   ])
 


### PR DESCRIPTION
Modifies the properties protected from overwrites by the following logic:
- Even though we want to, we shouldn't protect properties that existed before 5.0.0
  - Therefore, `isMetaMask` and `_metamask` are no longer protected
- Since we continue to protect `request`, let's also protect the two new private properties it relies on to function:
  - `_rpcRequest`
  - `_rpcEngine`