### PR TITLE
Add updated automatic reload on network change

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -68,7 +68,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       isConnected: undefined,
       accounts: undefined,
       isUnlocked: undefined,
-      reloadOnChainChange: true,
+      reloadOnChainChange: false,
     }
 
     this._metamask = this._getExperimentalApi()

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -14,7 +14,6 @@ const messages = require('./messages')
 const { sendSiteMetadata } = require('./siteMetadata')
 const {
   createErrorMiddleware,
-  defineAutoReloadProperties,
   EMITTED_NOTIFICATIONS,
   getRpcPromiseCallback,
   logStreamDisconnectWarning,
@@ -630,4 +629,45 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       result,
     }
   }
+}
+
+/**
+ * Defines the reload on chain change properties on a provider instance.
+ * Intended for use in MetamaskInpageProvider constructor.
+ *
+ * This helper exists because we want these properties to refer to an internal
+ * state value, via get/set handlers, and also be enumerable.
+ *
+ * @param {MetamaskInpageProvider} instance - The provider instance.
+ */
+function defineAutoReloadProperties (instance) {
+
+  const autoRefreshWarning = () => {
+    if (!instance._state.sentWarnings.autoRefresh) {
+      log.warn(messages.warnings.autoRefreshDeprecation)
+      instance._state.sentWarnings.autoRefresh = true
+    }
+  }
+
+  Object.defineProperty(instance, 'autoRefreshOnNetworkChange', {
+    enumerable: true,
+    get: () => {
+      autoRefreshWarning()
+      return instance._state.reloadOnChainChange
+    },
+    set: (value) => {
+      autoRefreshWarning()
+      instance._state.reloadOnChainChange = Boolean(value)
+    },
+  })
+
+  Object.defineProperty(instance, 'reloadOnChainChange', {
+    enumerable: true,
+    get: () => {
+      return instance._state.reloadOnChainChange
+    },
+    set: (value) => {
+      instance._state.reloadOnChainChange = Boolean(value)
+    },
+  })
 }

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -18,7 +18,6 @@ function initProvider ({
 } = {}) {
 
   let wasAccessed = false
-  let isReloading = false
 
   if (!connectionStream) {
     throw new Error('Must provide a connection stream.')
@@ -30,10 +29,7 @@ function initProvider ({
 
   provider.once('chainChanged', () => {
     if (wasAccessed && provider.reloadOnChainChange) {
-      if (!isReloading) {
-        isReloading = true
-        setTimeout(() => window.location.reload(), 250)
-      }
+      window.location.reload()
     }
   })
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -5,7 +5,7 @@ module.exports = {
     unsupportedSync: (method) => `MetaMask: The MetaMask Web3 object does not support synchronous methods like ${method} without a callback parameter.`, // TODO:deprecation:remove
   },
   warnings: {
-    // TODO:deprecation:remove
+    // deprecated properties
     autoRefreshDeprecation: `MetaMask: 'ethereum.autoRefreshOnNetworkChange' is deprecated and may be removed in the future. Please use 'ethereum.reloadOnChainChange' instead.`,
     // deprecated methods
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,

--- a/src/messages.js
+++ b/src/messages.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   warnings: {
     // TODO:deprecation:remove
-    autoReloadDeprecation: `MetaMask: MetaMask will soon stop reloading pages on network change.\nFor more information, see: https://medium.com/metamask/no-longer-reloading-pages-on-network-change-fbf041942b44 \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning: https://metamask.github.io/metamask-docs/API_Reference/Ethereum_Provider#ethereum.autorefreshonnetworkchange`,
+    autoRefreshDeprecation: `MetaMask: 'ethereum.autoRefreshOnNetworkChange' is deprecated and may be removed in the future. Please use 'ethereum.reloadOnChainChange' instead.`,
     // deprecated methods
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
     isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and may be removed in the future. Please listen for the relevant events instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events')
 const log = require('loglevel')
 const { ethErrors, serializeError } = require('eth-json-rpc-errors')
 const SafeEventEmitter = require('safe-event-emitter')
+const messages = require('./messages')
 
 // utility functions
 
@@ -65,6 +66,47 @@ function logStreamDisconnectWarning (remoteLabel, err) {
   }
 }
 
+/**
+ * Defines the reload on chain change properties on a provider instance.
+ * Intended for use in MetamaskInpageProvider constructor.
+ *
+ * This helper exists because we want these properties to refer to an internal
+ * state value, via get/set handlers, and also be enumerable.
+ *
+ * @param {MetamaskInpageProvider} instance - The provider instance.
+ */
+function defineAutoReloadProperties (instance) {
+
+  const autoRefreshWarning = () => {
+    if (!instance._state.sentWarnings.autoRefresh) {
+      log.warn(messages.warnings.autoRefreshDeprecation)
+      instance._state.sentWarnings.autoRefresh = true
+    }
+  }
+
+  Object.defineProperty(instance, 'autoRefreshOnNetworkChange', {
+    enumerable: true,
+    get: () => {
+      autoRefreshWarning()
+      return instance._state.reloadOnChainChange
+    },
+    set: (value) => {
+      autoRefreshWarning()
+      instance._state.reloadOnChainChange = Boolean(value)
+    },
+  })
+
+  Object.defineProperty(instance, 'reloadOnChainChange', {
+    enumerable: true,
+    get: () => {
+      return instance._state.reloadOnChainChange
+    },
+    set: (value) => {
+      instance._state.reloadOnChainChange = Boolean(value)
+    },
+  })
+}
+
 // eslint-disable-next-line no-empty-function
 const NOOP = () => {}
 
@@ -76,6 +118,7 @@ const EMITTED_NOTIFICATIONS = [
 
 module.exports = {
   createErrorMiddleware,
+  defineAutoReloadProperties,
   EMITTED_NOTIFICATIONS,
   getRpcPromiseCallback,
   logStreamDisconnectWarning,

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,6 @@ const EventEmitter = require('events')
 const log = require('loglevel')
 const { ethErrors, serializeError } = require('eth-json-rpc-errors')
 const SafeEventEmitter = require('safe-event-emitter')
-const messages = require('./messages')
 
 // utility functions
 
@@ -66,47 +65,6 @@ function logStreamDisconnectWarning (remoteLabel, err) {
   }
 }
 
-/**
- * Defines the reload on chain change properties on a provider instance.
- * Intended for use in MetamaskInpageProvider constructor.
- *
- * This helper exists because we want these properties to refer to an internal
- * state value, via get/set handlers, and also be enumerable.
- *
- * @param {MetamaskInpageProvider} instance - The provider instance.
- */
-function defineAutoReloadProperties (instance) {
-
-  const autoRefreshWarning = () => {
-    if (!instance._state.sentWarnings.autoRefresh) {
-      log.warn(messages.warnings.autoRefreshDeprecation)
-      instance._state.sentWarnings.autoRefresh = true
-    }
-  }
-
-  Object.defineProperty(instance, 'autoRefreshOnNetworkChange', {
-    enumerable: true,
-    get: () => {
-      autoRefreshWarning()
-      return instance._state.reloadOnChainChange
-    },
-    set: (value) => {
-      autoRefreshWarning()
-      instance._state.reloadOnChainChange = Boolean(value)
-    },
-  })
-
-  Object.defineProperty(instance, 'reloadOnChainChange', {
-    enumerable: true,
-    get: () => {
-      return instance._state.reloadOnChainChange
-    },
-    set: (value) => {
-      instance._state.reloadOnChainChange = Boolean(value)
-    },
-  })
-}
-
 // eslint-disable-next-line no-empty-function
 const NOOP = () => {}
 
@@ -118,7 +76,6 @@ const EMITTED_NOTIFICATIONS = [
 
 module.exports = {
   createErrorMiddleware,
-  defineAutoReloadProperties,
   EMITTED_NOTIFICATIONS,
   getRpcPromiseCallback,
   logStreamDisconnectWarning,


### PR DESCRIPTION
Per recent discussions, we decided to continue automatically reloading the page on network change. This PR introduces a new property (with a sensible name) for that purpose, and adds the automatic reload functionality to `initProvider`.

### Summary of Changes

- Add `reloadOnChainChange` property
- Use `Object.defineProperty` to define `reloadOnChainChange` and the (deprecated) `autoRefreshOnNetworkChange` alias on provider instances
- Update relevant messages