### PR TITLE
Un-deprecate isConnected

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -51,7 +51,6 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         // methods
         enable: false,
         experimentalMethods: false,
-        isConnected: false,
         send: false,
         // events
         events: {
@@ -216,8 +215,13 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   //====================
 
   /**
-   * Experimental. The signature of this method may change without warning, pending EIP 1193.
-   *
+   * Returns whether the inpage provider is connected to MetaMask.
+   */
+  isConnected () {
+    return this._state.isConnected
+  }
+
+  /**
    * Submits an RPC request to MetaMask for the given method, with the given params.
    * Resolves with the result of the method call, or rejects on error.
    *
@@ -525,19 +529,6 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   //====================
   // Deprecated Methods
   //====================
-
-  /**
-   * DEPRECATED.
-   * Returns whether the inpage provider is connected to MetaMask.
-   */
-  isConnected () {
-
-    if (!this._state.sentWarnings.isConnected) {
-      log.warn(messages.warnings.isConnectedDeprecation)
-      this._state.sentWarnings.isConnected = true
-    }
-    return this._state.isConnected
-  }
 
   /**
    * DEPRECATED.

--- a/src/messages.js
+++ b/src/messages.js
@@ -9,7 +9,6 @@ module.exports = {
     autoRefreshDeprecation: `MetaMask: MetaMask will soon stop reloading pages on network change.\nFor more information, see: https://docs.metamask.io/guide/ethereum-provider.html#ethereum-autorefreshonnetworkchange \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning.`,
     // deprecated methods
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
-    isConnectedDeprecation: `MetaMask: 'ethereum.isConnected()' is deprecated and may be removed in the future. Please listen for the relevant events instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and may be removed in the future. Please use 'ethereum.sendAsync(...)' or 'ethereum.request(...)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     // deprecated events
     events: {


### PR DESCRIPTION
- Un-deprecate `ethereum.isConnected`
- Remove comment marking `request` as experimental
  - The review period of EIP-1193 has ended, and there will be no significant changes to its API