### PR TITLE
Restore 'data' event

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -56,6 +56,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         events: {
           chainIdChanged: false,
           close: false,
+          data: false,
           networkChanged: false,
           notification: false,
         },
@@ -168,6 +169,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
     // json rpc notification listener
     jsonRpcConnection.events.on('notification', (payload) => {
+      this.emit('data', payload) // deprecated
       if (payload.method === 'wallet_accountsChanged') {
         this._handleAccountsChanged(payload.result)
       } else if (EMITTED_NOTIFICATIONS.includes(payload.method)) {


### PR DESCRIPTION
The `data` event was emitted from v3.0.0 of the inpage provider whenever a `notification` event was received from MetaMask. This event was removed in #11 because it was thought it was only used internally. Apparently `web3` was relying upon it though.

It has been restored exactly as it was in v3.0.0, except now a deprecation warning is shown in the console the first time a listener is added for this event.