### PR TITLE
Restore notification event value

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -184,7 +184,9 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         })
 
         // deprecated
-        this.emit('notification', (params && params.result) || payload)
+        if (params) {
+          this.emit('notification', params.result)
+        }
       }
     })
 

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -169,15 +169,20 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
     // json rpc notification listener
     jsonRpcConnection.events.on('notification', (payload) => {
+
       this.emit('data', payload) // deprecated
-      if (payload.method === 'wallet_accountsChanged') {
-        this._handleAccountsChanged(payload.result)
-      } else if (EMITTED_NOTIFICATIONS.includes(payload.method)) {
-        this.emit('notification', payload) // deprecated
+
+      const { method, params, result } = payload
+
+      if (method === 'wallet_accountsChanged') {
+        this._handleAccountsChanged(result)
+      } else if (EMITTED_NOTIFICATIONS.includes(method)) {
         this.emit('message', {
-          type: payload.method,
-          data: payload.params,
+          type: method,
+          data: params,
         })
+        // deprecated
+        this.emit('notification', (params && params.result) || payload)
       }
     })
 

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -177,10 +177,12 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       if (method === 'wallet_accountsChanged') {
         this._handleAccountsChanged(result)
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
+
         this.emit('message', {
           type: method,
           data: params,
         })
+
         // deprecated
         this.emit('notification', (params && params.result) || payload)
       }


### PR DESCRIPTION
Restores the emitted value of the `notification` event to its pre-`4.0.0` state, per: https://github.com/MetaMask/metamask-extension/blob/5e8a80e21d667b3c18a931e3da8f136b990bf14c/app/scripts/createStandardProvider.js#L32

Changing the value of the `notification` event was an unintended breaking change.