### PR TITLE
Add `publicConfigStore` alias

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -63,6 +63,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         // misc
         // TODO:deprecation:remove
         autoRefresh: false,
+        publicConfigStore: false,
       },
       isConnected: undefined,
       accounts: undefined,
@@ -219,6 +220,14 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         this._state.sentWarnings.autoRefresh = true
       }
     }, 1000)
+  }
+
+  get publicConfigStore () {
+    if (!this._state.sentWarnings.publicConfigStore) {
+      log.warn(messages.warnings.publicConfigStore)
+      this._state.sentWarnings.publicConfigStore = true
+    }
+    return this._publicConfigStore
   }
 
   //====================

--- a/src/messages.js
+++ b/src/messages.js
@@ -19,5 +19,6 @@ module.exports = {
     },
     // misc
     experimentalMethods: `MetaMask: 'ethereum._metamask' exposes non-standard, experimental methods. They may be removed or changed without warning.`,
+    publicConfigStore: `MetaMask: The property 'publicConfigStore' is deprecated and WILL be removed in the future.`,
   },
 }


### PR DESCRIPTION
An alias has been added to restore the `publicConfigStore` property that was renamed in #11. A warning is printed to the console upon first use, explaining that the property is deprecated and will be removed in the future.

Fixes #67