### PR TITLE
Add missing `data` event warning

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -14,6 +14,7 @@ module.exports = {
     events: {
       chainIdChanged: `MetaMask: The event 'chainIdChanged' is deprecated and WILL be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
       close: `MetaMask: The event 'close' is deprecated and may be removed in the future. Please use 'disconnect' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+      data: `MetaMask: The event 'data' is deprecated and may be removed in the future.`,
       networkChanged: `MetaMask: The event 'networkChanged' is deprecated and may be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
       notification: `MetaMask: The event 'notification' is deprecated and may be removed in the future. Please use 'message' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     },


### PR DESCRIPTION
The `data` event was restored in #62 with a deprecation warning, but the deprecation warning message was missing. The message has now been added.

Fixes #66