### PR TITLE
Skip emitting `data` event for `wallet_accountsChanged`

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -171,13 +171,15 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // json rpc notification listener
     jsonRpcConnection.events.on('notification', (payload) => {
 
-      this.emit('data', payload) // deprecated
-
       const { method, params, result } = payload
 
       if (method === 'wallet_accountsChanged') {
         this._handleAccountsChanged(result)
-      } else if (EMITTED_NOTIFICATIONS.includes(method)) {
+        return
+      }
+
+      if (EMITTED_NOTIFICATIONS.includes(method)) {
+        this.emit('data', payload) // deprecated
 
         this.emit('message', {
           type: method,
@@ -185,9 +187,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         })
 
         // deprecated
-        if (params) {
-          this.emit('notification', params.result)
-        }
+        this.emit('notification', params.result)
       }
     })
 


### PR DESCRIPTION
The `data` event was being used by some dapps (via `web3@1.x` for example) in a way that we didn't anticpiate. Specifically these dapps were expecting the payload for this event to contain a `params` property, and they were breaking if this was absent.

We hadn't intended this event for public consumption in the first place, but we _especially_ didn't mean for `wallet_accountsChanged` to be sent to dapps. So for now the easiest solution is to not emit `data` for these events.

Currently the only other notification sent from the extension is `eth_subscription`, so the `data` event has been moved inside the block that checks for that type. The `params` check was removed for being redundant, since `eth_subscription` messages should always include a `params` property.