### PR TITLE
Update getSiteIcon logic

### DIFF
--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -68,17 +68,11 @@ function getSiteName (window) {
 async function getSiteIcon (window) {
   const { document } = window
 
-  // Use the site's favicon if it exists
-  let icon = document.querySelector('head > link[rel="shortcut icon"]')
-  if (icon && await resourceExists(icon.href)) {
-    return icon.href
-  }
-
-  // Search through available icons in no particular order
-  icon = Array.from(document.querySelectorAll('head > link[rel="icon"]'))
-    .find((_icon) => Boolean(_icon.href))
-  if (icon && await resourceExists(icon.href)) {
-    return icon.href
+  const icons = document.querySelectorAll('head > link[rel~="icon"]')
+  for (const icon of icons) {
+    if (icon && await resourceExists(icon.href)) {
+      return true
+    }
   }
 
   return null
@@ -87,9 +81,17 @@ async function getSiteIcon (window) {
 /**
  * Returns whether the given resource exists
  * @param {string} url the url of the resource
+ * @return {Promise<boolean>} whether the resource exists
  */
 function resourceExists (url) {
-  return fetch(url, { method: 'HEAD', mode: 'same-origin' })
-    .then((res) => res.status === 200)
-    .catch((_) => false)
+  return new Promise((resolve, reject) => {
+    try {
+      const img = document.createElement('img')
+      img.onload = () => resolve(true)
+      img.onerror = () => resolve(false)
+      img.src = url
+    } catch (e) {
+      reject(e)
+    }
+  })
 }


### PR DESCRIPTION
This change updates the `getSiteIcon` logic in two ways:

1. Use `img` elements for testing resource existence rather than `fetch`

    The previous implementation of `resourceExists` was using the `same-origin` mode for fetch, but that would break when a site used another domain for their icons, `static.example.com` or `images.example.com`, for example. There isn't a fetch mode that works here. There's no guarantee that the 2nd origin in question is correctly configured for CORS—so that's `cors` and `same-origin` out. `navigate` doesn't apply and `no-cors` hides the `status` and `statusText` so we can't confirm that.<sup>[\[1\]][1]</sup>

2. Handle multiple link elements with `rel=icon`

    It is very possible and even recommended that there are multiple icons, and if we're going to check that they actually exist, we should fallback to the other images listed.

    e.g.:

       <link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-16x16.png" sizes="16x16">
       <link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-32x32.png" sizes="32x32">
       <link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-96x96.png" sizes="96x96">

There is a subtle functionality change here in that the element matching `head > link[rel="shortcut icon"]` will be checked first, but that isn't important, nor should it be.

  [1]:https://fetch.spec.whatwg.org/#concept-request-mode