### PR TITLE
Handle multiple link elements with `rel=icon`

### DIFF
--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -68,17 +68,11 @@ function getSiteName (window) {
 async function getSiteIcon (window) {
   const { document } = window
 
-  // Use the site's favicon if it exists
-  let icon = document.querySelector('head > link[rel="shortcut icon"]')
-  if (icon && await resourceExists(icon.href)) {
-    return icon.href
-  }
-
-  // Search through available icons in no particular order
-  icon = Array.from(document.querySelectorAll('head > link[rel="icon"]'))
-    .find((_icon) => Boolean(_icon.href))
-  if (icon && await resourceExists(icon.href)) {
-    return icon.href
+  const icons = document.querySelectorAll('head > link[rel~="icon"]')
+  for (const icon of icons) {
+    if (icon && await resourceExists(icon.href)) {
+      return true
+    }
   }
 
   return null

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -64,7 +64,7 @@ function getSiteName (window) {
 
 /**
  * Extracts an icon for the site from the DOM
- * @returns {string|null} a icon URL
+ * @returns {string|null} an icon URL
  */
 async function getSiteIcon (window) {
   const { document } = window

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -64,6 +64,7 @@ function getSiteName (window) {
 
 /**
  * Extracts an icon for the site from the DOM
+ * @returns {string} a icon URL
  */
 async function getSiteIcon (window) {
   const { document } = window
@@ -71,7 +72,7 @@ async function getSiteIcon (window) {
   const icons = document.querySelectorAll('head > link[rel~="icon"]')
   for (const icon of icons) {
     if (icon && await imgExists(icon.href)) {
-      return true
+      return icon.href
     }
   }
 

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -64,7 +64,7 @@ function getSiteName (window) {
 
 /**
  * Extracts an icon for the site from the DOM
- * @returns {string} a icon URL
+ * @returns {string|null} a icon URL
  */
 async function getSiteIcon (window) {
   const { document } = window


### PR DESCRIPTION
Extracted from #75

It is very possible—even recommended—that there are multiple icons and if we're going to check that they actually exist, we should fallback to the other images listed.

e.g.:

```html
<link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-16x16.png" sizes="16x16">
<link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-32x32.png" sizes="32x32">
<link rel="icon" type="image/png" href="https://cdn.yourwebsite.com/favicon-96x96.png" sizes="96x96">
```

There is a subtle functionality change here in that the element matching `head > link[rel="shortcut icon"]` will no longer be checked first, but that isn't important, nor should it be. That said, not checking for `rel="shortcut icon"` first could also be an improvement since its usage isn't quite correct or modern:<sup>[\[1\]][1]</sup>

> For [historical reasons](https://www.w3.org/Bugs/Public/show_bug.cgi?id=12695), the HTML specification [now allows](https://html.spec.whatwg.org/multipage/semantics.html#rel-icon) the use of `shortcut` as a link relation if it’s immediately followed by a single U+0020 space character and the `icon` keyword.

  [1]:https://mathiasbynens.be/notes/rel-shortcut-icon