### PR TITLE
Use mode:cors when checking for site icons

### DIFF
--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -89,7 +89,7 @@ async function getSiteIcon (window) {
  * @param {string} url the url of the resource
  */
 function resourceExists (url) {
-  return fetch(url, { method: 'HEAD', mode: 'same-origin' })
+  return fetch(url, { method: 'HEAD', mode: 'cors' })
     .then((res) => res.status === 200)
     .catch((_) => false)
 }


### PR DESCRIPTION
This is a different approach than #75
Closes #78

This change updates the fetch mode we use when requesting site icons to use `cors` instead of `same-origin` as `same-origin` breaks when a site uses a different domain for their icons, e.g. `static.example.com` or `images.example.com`. While it is also possible that the 2nd origin here isn't correctly configured for CORS that's a fewer sites breaking.