### PR TITLE
Use `img` elements for testing resource existence rather than `fetch`

### DIFF
--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -70,14 +70,14 @@ async function getSiteIcon (window) {
 
   // Use the site's favicon if it exists
   let icon = document.querySelector('head > link[rel="shortcut icon"]')
-  if (icon && await resourceExists(icon.href)) {
+  if (icon && await imgExists(icon.href)) {
     return icon.href
   }
 
   // Search through available icons in no particular order
   icon = Array.from(document.querySelectorAll('head > link[rel="icon"]'))
     .find((_icon) => Boolean(_icon.href))
-  if (icon && await resourceExists(icon.href)) {
+  if (icon && await imgExists(icon.href)) {
     return icon.href
   }
 
@@ -85,11 +85,19 @@ async function getSiteIcon (window) {
 }
 
 /**
- * Returns whether the given resource exists
- * @param {string} url the url of the resource
+ * Returns whether the given image URL exists
+ * @param {string} url - the url of the image
+ * @return {Promise<boolean>} whether the image exists
  */
-function resourceExists (url) {
-  return fetch(url, { method: 'HEAD', mode: 'same-origin' })
-    .then((res) => res.status === 200)
-    .catch((_) => false)
+function imgExists (url) {
+  return new Promise((resolve, reject) => {
+    try {
+      const img = document.createElement('img')
+      img.onload = () => resolve(true)
+      img.onerror = () => resolve(false)
+      img.src = url
+    } catch (e) {
+      reject(e)
+    }
+  })
 }


### PR DESCRIPTION
Closes #77

The previous implementation of `resourceExists` was using the `same-origin` mode for fetch but that breaks when a site uses another domain for their icons—`static.example.com`, `assets.example.com`, or `images.example.com`, for example.

There isn't a fetch mode that works here:<sup>[\[1\]][1]</sup>

- **`same-origin`** doesn't work for the reasons described
- **`cors`** there's no guarantee that the 2nd origin in question is correctly configured for CORS—a quick check on two sites confirmed this
- **`navigate`** isn't applicable here
- **`no-cors`** hides the `status` and `statusText` so we can't use those

With that, this PR loads the resources as images and tests whether that works. This will essentially be a `no-cors` request but with the status exposed through `onload`+`onerror`, which will suffice for our use case.

  [1]:https://fetch.spec.whatwg.org/#concept-request-mode