### PR TITLE
Validate constructor stream parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "eth-json-rpc-errors": "^2.0.2",
     "fast-deep-equal": "^2.0.1",
+    "is-stream": "^2.0.0",
     "json-rpc-engine": "^5.1.5",
     "json-rpc-middleware-stream": "^2.1.1",
     "loglevel": "^1.6.1",

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -24,7 +24,7 @@ const {
 module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   /**
-   * @param {Object} connectionStream - A Node.js stream
+   * @param {Object} connectionStream - A Node.js duplex stream
    * @param {Object} opts - An options bag
    * @param {number} opts.maxEventListeners - The maximum number of event listeners
    * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -9,6 +9,7 @@ const SafeEventEmitter = require('safe-event-emitter')
 const dequal = require('fast-deep-equal')
 const { ethErrors } = require('eth-json-rpc-errors')
 const log = require('loglevel')
+const { duplex: isDuplex } = require('is-stream')
 
 const messages = require('./messages')
 const { sendSiteMetadata } = require('./siteMetadata')
@@ -32,6 +33,10 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     connectionStream,
     { shouldSendMetadata = true, maxEventListeners = 100 } = {},
   ) {
+
+    if (!isDuplex(connectionStream)) {
+      throw new Error('Must provide a duplex stream.')
+    }
 
     if (
       typeof shouldSendMetadata !== 'boolean' || typeof maxEventListeners !== 'number'

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -17,10 +17,6 @@ function initProvider ({
   shouldSetOnWindow = true,
 } = {}) {
 
-  if (!connectionStream) {
-    throw new Error('Must provide a connection stream.')
-  }
-
   let provider = new MetamaskInpageProvider(
     connectionStream, { shouldSendMetadata, maxEventListeners },
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,11 @@ is-regex@^1.0.5:
   dependencies:
     has "^1.0.3"
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-string@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"


### PR DESCRIPTION
For testing purposes, it's nice to have a specific error if an obviously invalid stream is passed. If it's not, things fail later in the constructor for unpredictable reasons.

- Adds `is-stream` as a dependency, which has no dependencies and is [tiny](https://bundlephobia.com/result?p=is-stream@2.0.0).
- Removes now-redundant stream argument check in `initProvider`