### PR TITLE
eth-rpc-errors@2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "src/"
   ],
   "dependencies": {
-    "eth-json-rpc-errors": "^2.0.2",
+    "eth-rpc-errors": "^2.1.1",
     "fast-deep-equal": "^2.0.1",
     "is-stream": "^2.0.0",
     "json-rpc-engine": "^5.1.5",

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -7,7 +7,7 @@ const asStream = require('obs-store/lib/asStream')
 const ObjectMultiplex = require('obj-multiplex')
 const SafeEventEmitter = require('safe-event-emitter')
 const dequal = require('fast-deep-equal')
-const { ethErrors } = require('eth-json-rpc-errors')
+const { ethErrors } = require('eth-rpc-errors')
 const log = require('loglevel')
 const { duplex: isDuplex } = require('is-stream')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,12 @@
 const EventEmitter = require('events')
 const log = require('loglevel')
-const { ethErrors, serializeError } = require('eth-json-rpc-errors')
+const { ethErrors } = require('eth-rpc-errors')
 const SafeEventEmitter = require('safe-event-emitter')
 
 // utility functions
 
 /**
- * json-rpc-engine middleware that both logs standard and non-standard error
- * messages and ends middleware stack traversal if an error is encountered
+ * json-rpc-engine middleware that logs RPC errors and and validates req.method.
  *
  * @returns {Function} json-rpc-engine middleware function
  */
@@ -15,7 +14,7 @@ function createErrorMiddleware () {
   return (req, res, next) => {
 
     // json-rpc-engine will terminate the request when it notices this error
-    if (!req.method || typeof req.method !== 'string') {
+    if (typeof req.method !== 'string' || !req.method) {
       res.error = ethErrors.rpc.invalidRequest({
         message: `The request 'method' must be a non-empty string.`,
         data: req,
@@ -27,7 +26,6 @@ function createErrorMiddleware () {
       if (!error) {
         return done()
       }
-      serializeError(error)
       log.error(`MetaMask - RPC Error: ${error.message}`, error)
       return done()
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,10 +474,10 @@ eth-json-rpc-errors@^2.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-errors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
-  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
+eth-rpc-errors@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
+  integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
   dependencies:
     fast-safe-stringify "^2.0.6"
 


### PR DESCRIPTION
- Removes `eth-json-rpc-errors`, which is deprecated
- Adds `eth-rpc-errors@2.1.1`
- Removes call to `serializeError` that has done nothing for quite some time
  - `serializeError` returns a serialized error, while it was used as though it modified the error in place.
- Minor cleanup of comments and order of logical operations in `createMiddleware`
  - All non-functional