### PR TITLE
Remove loglevel

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "is-stream": "^2.0.0",
     "json-rpc-engine": "^5.2.0",
     "json-rpc-middleware-stream": "^2.1.1",
-    "loglevel": "^1.6.1",
     "obj-multiplex": "^1.0.0",
     "obs-store": "^4.0.3",
     "pump": "^3.0.0",

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -8,7 +8,6 @@ const ObjectMultiplex = require('obj-multiplex')
 const SafeEventEmitter = require('safe-event-emitter')
 const dequal = require('fast-deep-equal')
 const { ethErrors } = require('eth-rpc-errors')
-const log = require('loglevel')
 const { duplex: isDuplex } = require('is-stream')
 
 const messages = require('./messages')
@@ -224,7 +223,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // wait a second to attempt to send this, so that the warning can be silenced
     setTimeout(() => {
       if (this.autoRefreshOnNetworkChange && !this._state.sentWarnings.autoRefresh) {
-        log.warn(messages.warnings.autoRefreshDeprecation)
+        console.warn(messages.warnings.autoRefreshDeprecation)
         this._state.sentWarnings.autoRefresh = true
       }
     }, 1000)
@@ -232,7 +231,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   get publicConfigStore () {
     if (!this._state.sentWarnings.publicConfigStore) {
-      log.warn(messages.warnings.publicConfigStore)
+      console.warn(messages.warnings.publicConfigStore)
       this._state.sentWarnings.publicConfigStore = true
     }
     return this._publicConfigStore
@@ -427,7 +426,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     let _accounts = accounts
 
     if (!Array.isArray(accounts)) {
-      log.error(
+      console.error(
         'MetaMask: Received non-array accounts parameter. Please report this bug.',
         accounts,
       )
@@ -440,7 +439,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       // we should always have the correct accounts even before eth_accounts
       // returns, except in cases where isInternal is true
       if (isEthAccounts && this._state.accounts !== undefined && !isInternal) {
-        log.error(
+        console.error(
           `MetaMask: 'eth_accounts' unexpectedly updated accounts. Please report this bug.`,
           _accounts,
         )
@@ -554,7 +553,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         get: (obj, prop) => {
 
           if (!this._state.sentWarnings.experimentalMethods) {
-            log.warn(messages.warnings.experimentalMethods)
+            console.warn(messages.warnings.experimentalMethods)
             this._state.sentWarnings.experimentalMethods = true
           }
           return obj[prop]
@@ -576,7 +575,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   enable () {
 
     if (!this._state.sentWarnings.enable) {
-      log.warn(messages.warnings.enableDeprecation)
+      console.warn(messages.warnings.enableDeprecation)
       this._state.sentWarnings.enable = true
     }
 
@@ -604,7 +603,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   send (methodOrPayload, callbackOrArgs) {
 
     if (!this._state.sentWarnings.send) {
-      log.warn(messages.warnings.sendDeprecation)
+      console.warn(messages.warnings.sendDeprecation)
       this._state.sentWarnings.send = true
     }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const EventEmitter = require('events')
-const log = require('loglevel')
 const { ethErrors } = require('eth-rpc-errors')
 const SafeEventEmitter = require('safe-event-emitter')
 
@@ -26,7 +25,7 @@ function createErrorMiddleware () {
       if (!error) {
         return done()
       }
-      log.error(`MetaMask - RPC Error: ${error.message}`, error)
+      console.error(`MetaMask - RPC Error: ${error.message}`, error)
       return done()
     })
   }
@@ -48,14 +47,14 @@ const getRpcPromiseCallback = (resolve, reject, unwrapResult = true) => (error, 
  * EventEmitter that has listeners for the 'error' event.
  *
  * @param {string} remoteLabel - The label of the disconnected stream.
- * @param {Error} err - The associated error to log.
+ * @param {Error} err - The associated error to console.
  */
 function logStreamDisconnectWarning (remoteLabel, err) {
   let warningMsg = `MetamaskInpageProvider - lost connection to ${remoteLabel}`
   if (err) {
     warningMsg += `\n${err.stack}`
   }
-  log.warn(warningMsg)
+  console.warn(warningMsg)
   if (this instanceof EventEmitter || this instanceof SafeEventEmitter) {
     if (this.listenerCount('error') > 0) {
       this.emit('error', warningMsg)

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,11 +822,6 @@ lodash@^4.17.14, lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
-loglevel@^1.6.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
-  integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"


### PR DESCRIPTION
- Remove `loglevel`
- Replace usage of `loglevel` with `console`

There's not really a point to this dependency; I think it's a leftover from when the various messages were logged in the extension inpage script.