### PR TITLE
Enable package consumers to specify a logger

### DIFF
--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -22,12 +22,22 @@ const {
 
 let log
 
+/**
+ * @typedef {Object} ConsoleLike
+ * @property {function} debug - Like console.debug
+ * @property {function} error - Like console.error
+ * @property {function} info - Like console.info
+ * @property {function} log - Like console.log
+ * @property {function} trace - Like console.trace
+ * @property {function} warn - Like console.warn
+ */
+
 module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   /**
    * @param {Object} connectionStream - A Node.js duplex stream
    * @param {Object} opts - An options bag
-   * @param {Object} [opts.logger] - The logging API to use. Default: console
+   * @param {ConsoleLike} [opts.logger] - The logging API to use. Default: console
    * @param {number} [opts.maxEventListeners] - The maximum number of event
    * listeners. Default: 100
    * @param {boolean} [opts.shouldSendMetadata] - Whether the provider should

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -156,7 +156,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       mux.createStream('publicConfig'),
       asStream(this._publicConfigStore),
       // RPC requests should still work if only this stream fails
-      logStreamDisconnectWarning.bind(this, 'MetaMask PublicConfigStore'),
+      logStreamDisconnectWarning.bind(this, log, 'MetaMask PublicConfigStore'),
     )
 
     // ignore phishing warning message (handled elsewhere)
@@ -407,7 +407,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
    */
   _handleDisconnect (streamName, err) {
 
-    logStreamDisconnectWarning.bind(this, log)(streamName, err)
+    logStreamDisconnectWarning.bind(this)(log, streamName, err)
 
     const disconnectError = {
       code: 1011,

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -42,6 +42,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     } = {},
   ) {
 
+    validateLoggerObject(logger)
     log = logger
 
     if (!isDuplex(connectionStream)) {
@@ -676,5 +677,20 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       jsonrpc: payload.jsonrpc,
       result,
     }
+  }
+}
+
+function validateLoggerObject (logger) {
+  if (logger !== console) {
+    if (typeof logger === 'object') {
+      const methodKeys = ['log', 'warn', 'error', 'debug', 'info', 'trace']
+      for (const key of methodKeys) {
+        if (typeof logger[key] !== 'function') {
+          throw new Error(messages.errors.invalidLoggerMethod(key))
+        }
+      }
+      return
+    }
+    throw new Error(messages.errors.invalidLoggerObject())
   }
 }

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -20,18 +20,29 @@ const {
   NOOP,
 } = require('./utils')
 
+let log
+
 module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   /**
    * @param {Object} connectionStream - A Node.js duplex stream
    * @param {Object} opts - An options bag
-   * @param {number} opts.maxEventListeners - The maximum number of event listeners
-   * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata
+   * @param {Object} [opts.logger] - The logging API to use. Default: console
+   * @param {number} [opts.maxEventListeners] - The maximum number of event
+   * listeners. Default: 100
+   * @param {boolean} [opts.shouldSendMetadata] - Whether the provider should
+   * send page metadata. Default: true
    */
   constructor (
     connectionStream,
-    { maxEventListeners = 100, shouldSendMetadata = true } = {},
+    {
+      logger = console,
+      maxEventListeners = 100,
+      shouldSendMetadata = true,
+    } = {},
   ) {
+
+    log = logger
 
     if (!isDuplex(connectionStream)) {
       throw new Error(messages.errors.invalidDuplexStream())
@@ -171,7 +182,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // handle RPC requests via dapp-side rpc engine
     const rpcEngine = new RpcEngine()
     rpcEngine.push(createIdRemapMiddleware())
-    rpcEngine.push(createErrorMiddleware())
+    rpcEngine.push(createErrorMiddleware(log))
     rpcEngine.push(jsonRpcConnection.middleware)
     this._rpcEngine = rpcEngine
 
@@ -203,7 +214,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // send website metadata
     if (shouldSendMetadata) {
       const domContentLoadedHandler = () => {
-        sendSiteMetadata(this._rpcEngine)
+        sendSiteMetadata(this._rpcEngine, log)
         window.removeEventListener('DOMContentLoaded', domContentLoadedHandler)
       }
       window.addEventListener('DOMContentLoaded', domContentLoadedHandler)
@@ -223,7 +234,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     // wait a second to attempt to send this, so that the warning can be silenced
     setTimeout(() => {
       if (this.autoRefreshOnNetworkChange && !this._state.sentWarnings.autoRefresh) {
-        console.warn(messages.warnings.autoRefreshDeprecation)
+        log.warn(messages.warnings.autoRefreshDeprecation)
         this._state.sentWarnings.autoRefresh = true
       }
     }, 1000)
@@ -231,7 +242,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   get publicConfigStore () {
     if (!this._state.sentWarnings.publicConfigStore) {
-      console.warn(messages.warnings.publicConfigStore)
+      log.warn(messages.warnings.publicConfigStore)
       this._state.sentWarnings.publicConfigStore = true
     }
     return this._publicConfigStore
@@ -396,7 +407,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
    */
   _handleDisconnect (streamName, err) {
 
-    logStreamDisconnectWarning.bind(this)(streamName, err)
+    logStreamDisconnectWarning.bind(this, log)(streamName, err)
 
     const disconnectError = {
       code: 1011,
@@ -426,7 +437,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
     let _accounts = accounts
 
     if (!Array.isArray(accounts)) {
-      console.error(
+      log.error(
         'MetaMask: Received non-array accounts parameter. Please report this bug.',
         accounts,
       )
@@ -439,7 +450,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
       // we should always have the correct accounts even before eth_accounts
       // returns, except in cases where isInternal is true
       if (isEthAccounts && this._state.accounts !== undefined && !isInternal) {
-        console.error(
+        log.error(
           `MetaMask: 'eth_accounts' unexpectedly updated accounts. Please report this bug.`,
           _accounts,
         )
@@ -474,7 +485,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
    */
   _warnOfDeprecation (eventName) {
     if (this._state.sentWarnings.events[eventName] === false) {
-      console.warn(messages.warnings.events[eventName])
+      log.warn(messages.warnings.events[eventName])
       this._state.sentWarnings.events[eventName] = true
     }
   }
@@ -553,7 +564,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
         get: (obj, prop) => {
 
           if (!this._state.sentWarnings.experimentalMethods) {
-            console.warn(messages.warnings.experimentalMethods)
+            log.warn(messages.warnings.experimentalMethods)
             this._state.sentWarnings.experimentalMethods = true
           }
           return obj[prop]
@@ -575,7 +586,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   enable () {
 
     if (!this._state.sentWarnings.enable) {
-      console.warn(messages.warnings.enableDeprecation)
+      log.warn(messages.warnings.enableDeprecation)
       this._state.sentWarnings.enable = true
     }
 
@@ -603,7 +614,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   send (methodOrPayload, callbackOrArgs) {
 
     if (!this._state.sentWarnings.send) {
-      console.warn(messages.warnings.sendDeprecation)
+      log.warn(messages.warnings.sendDeprecation)
       this._state.sentWarnings.send = true
     }
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -8,6 +8,8 @@ module.exports = {
     invalidRequestArgs: () => `Expected a single, non-array, object argument.`,
     invalidRequestMethod: () => `'args.method' must be a non-empty string.`,
     invalidRequestParams: () => `'args.params' must be an object or array if provided.`,
+    invalidLoggerObject: () => `'args.logger' must be an object if provided.`,
+    invalidLoggerMethod: (method) => `'args.logger' must include required method '${method}'.`,
   },
   warnings: {
     // TODO:deprecation:remove

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -8,8 +8,11 @@ module.exports = {
 
 /**
  * Sends site metadata over an RPC request.
+ *
+ * @param {JsonRpcEngine} engine - The JSON RPC Engine to send metadata over.
+ * @param {Object} log - The logging API to use.
  */
-async function sendSiteMetadata (engine) {
+async function sendSiteMetadata (engine, log) {
   try {
     const domainMetadata = await getSiteMetadata()
     // call engine.handle directly to avoid normal RPC request handling
@@ -21,7 +24,7 @@ async function sendSiteMetadata (engine) {
       NOOP,
     )
   } catch (error) {
-    console.error({
+    log.error({
       message: errors.sendSiteMetadata(),
       originalError: error,
     })

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,9 +7,10 @@ const SafeEventEmitter = require('safe-event-emitter')
 /**
  * json-rpc-engine middleware that logs RPC errors and and validates req.method.
  *
+ * @param {Object} log - The logging API to use.
  * @returns {Function} json-rpc-engine middleware function
  */
-function createErrorMiddleware () {
+function createErrorMiddleware (log) {
   return (req, res, next) => {
 
     // json-rpc-engine will terminate the request when it notices this error
@@ -25,7 +26,7 @@ function createErrorMiddleware () {
       if (!error) {
         return done()
       }
-      console.error(`MetaMask - RPC Error: ${error.message}`, error)
+      log.error(`MetaMask - RPC Error: ${error.message}`, error)
       return done()
     })
   }
@@ -46,15 +47,16 @@ const getRpcPromiseCallback = (resolve, reject, unwrapResult = true) => (error, 
  * Logs a stream disconnection error. Emits an 'error' if bound to an
  * EventEmitter that has listeners for the 'error' event.
  *
+ * @param {Object} log - The logging API to use.
  * @param {string} remoteLabel - The label of the disconnected stream.
- * @param {Error} err - The associated error to console.
+ * @param {Error} err - The associated error to log.
  */
-function logStreamDisconnectWarning (remoteLabel, err) {
+function logStreamDisconnectWarning (log, remoteLabel, err) {
   let warningMsg = `MetamaskInpageProvider - lost connection to ${remoteLabel}`
   if (err) {
     warningMsg += `\n${err.stack}`
   }
-  console.warn(warningMsg)
+  log.warn(warningMsg)
   if (this instanceof EventEmitter || this instanceof SafeEventEmitter) {
     if (this.listenerCount('error') > 0) {
       this.emit('error', warningMsg)

--- a/test/MetamaskInpageProvider.misc.test.js
+++ b/test/MetamaskInpageProvider.misc.test.js
@@ -61,7 +61,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
 
       expect(
         () => new MetamaskInpageProvider(stream, null),
-      ).toThrow('Cannot destructure property `maxEventListeners` of \'undefined\' or \'null\'')
+      ).toThrow('Cannot destructure property `logger` of \'undefined\' or \'null\'')
 
       expect(
         () => new MetamaskInpageProvider(stream, {
@@ -76,6 +76,70 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
           shouldSendMetadata: true,
         }),
       ).toThrow(messages.errors.invalidOptions('foo', true))
+    })
+
+    it('accepts valid custom logger', () => {
+      const stream = new MockDuplexStream()
+      const customLogger = {
+        debug: console.debug,
+        error: console.error,
+        info: console.info,
+        log: console.log,
+        trace: console.trace,
+        warn: console.warn,
+      }
+
+      expect(
+        () => new MetamaskInpageProvider(stream, {
+          logger: customLogger,
+        }),
+      ).not.toThrow()
+    })
+
+    it('throws if non-object logger provided', () => {
+      const stream = new MockDuplexStream()
+
+      expect(
+        () => new MetamaskInpageProvider(stream, {
+          logger: 'foo',
+        }),
+      ).toThrow(messages.errors.invalidLoggerObject())
+    })
+
+    it('throws if provided logger is missing method key', () => {
+      const stream = new MockDuplexStream()
+      const customLogger = {
+        debug: console.debug,
+        error: console.error,
+        info: console.info,
+        log: console.log,
+        trace: console.trace,
+        // warn: console.warn, // missing
+      }
+
+      expect(
+        () => new MetamaskInpageProvider(stream, {
+          logger: customLogger,
+        }),
+      ).toThrow(messages.errors.invalidLoggerMethod('warn'))
+    })
+
+    it('throws if provided logger has invalid method', () => {
+      const stream = new MockDuplexStream()
+      const customLogger = {
+        debug: console.debug,
+        error: console.error,
+        info: console.info,
+        log: console.log,
+        trace: console.trace,
+        warn: 'foo', // not a function
+      }
+
+      expect(
+        () => new MetamaskInpageProvider(stream, {
+          logger: customLogger,
+        }),
+      ).toThrow(messages.errors.invalidLoggerMethod('warn'))
     })
   })
 


### PR DESCRIPTION
- Add named param `logger` to constructor
  - This object is assigned to a global variable `log`, which is used in place of `console` for all logging calls
  - By default, `logger = console`
- Validate `logger` param
  - Require `typeof 'object' === true` and the following methods:
    - `debug`
    - `error`
    - `info`
    - `log`
    - `trace`
  - Add `logger` validation tests