### PR TITLE
Touch up types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,53 +25,88 @@ export interface MetamaskInpageProviderOptions {
 export class MetamaskInpageProvider extends EventEmitter {
 
   /**
-   * @param connectionStream A Node.js duplex stream
-   * @param options An options bag
+   * @param connectionStream - A Node.js duplex stream.
+   * @param options - An options bag.
    */
   constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions);
 
+  /**
+   * Returns whether the provider can process RPC requests.
+   */
   isConnected (): boolean;
 
   /**
-   * Submits an RPC request to MetaMask for the given method, with the given params.
+   * Submits an RPC request for the given method, with the given params.
    * Resolves with the result of the method call, or rejects on error.
    */
   request (args: RequestArguments): Promise<unknown>;
 
+  /**
+   * Submits an RPC request per the given JSON-RPC request object.
+   */
   sendAsync (
-    payload: JsonRpcPayload,
+    payload: JsonRpcRequest,
     callback: (error: Error | null, result?: JsonRpcResponse) => void,
   ): void;
 
+  /**
+   * Submits an RPC request for the given method, with the given params.
+   * @deprecated Use {@link request} instead.
+   */
   send (method: string, params?: unknown[]): Promise<JsonRpcResponse>;
 
+  /**
+   * Submits an RPC request per the given JSON-RPC request object.
+   * @deprecated Use {@link request} instead.
+   */
   send (
-    payload: JsonRpcPayload,
+    payload: JsonRpcRequest,
     callback: (error: Error | null, result?: JsonRpcResponse) => void,
   ): void;
 
-  send (payload: SendSyncJsonRpcPayload): JsonRpcResponse;
+  /**
+   * Accepts a JSON-RPC request object, and synchronously returns the cached result
+   * for the given method. Only supports 4 specific methods.
+   * @deprecated Use {@link request} instead.
+   */
+  send (payload: SendSyncJsonRpcRequest): JsonRpcResponse;
 
+  /**
+   * Indicating that this provider is a MetaMask provider.
+   */
   readonly isMetaMask: true;
 
+  /**
+   * The user's currently selected Ethereum address.
+   * If null, MetaMask is either locked or the user has not permitted any
+   * addresses to be viewed.
+   */
   readonly selectedAddress: string | null;
 
+  /**
+   * The network ID of the currently connected Ethereum chain.
+   * @deprecated Use {@link chainId} instead.
+   */
   readonly networkVersion: string | null;
 
+  /**
+   * The chain ID of the currently connected Ethereum chain.
+   * See [chainId.network]{@link https://chainid.network} for more information.
+   */
   readonly chainId: string | undefined;
 }
 
 /**
- * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
+ * Initializes a MetamaskInpageProvider and (optionally) assigns it as window.ethereum.
  * @returns The initialized provider (whether set or not).
  */
 export function initProvider (
   opts: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
 
-    /** A Node.js duplex stream */
+    /** A Node.js duplex stream. */
     connectionStream: Duplex;
 
-    /** Whether the provider should be set as window.ethereum */
+    /** Whether the provider should be set as window.ethereum. */
     shouldSetOnWindow?: boolean;
   }
 ): MetamaskInpageProvider;
@@ -85,31 +120,52 @@ export function initProvider (
 export function setGlobalProvider (providerInstance: MetamaskInpageProvider): void;
 
 export interface RequestArguments {
+
+  /** The RPC method to request. */
   method: string;
+
+  /** The params of the RPC method, if any. */
   params?: unknown[];
 }
 
-/**
- * The jsonrpc and id properties will be handled if not provided.
- */
-export interface JsonRpcPayload {
+export interface JsonRpcRequest {
+
+  /** The RPC method to request. */
   method: string;
+
+  /** The params of the RPC method, if any. */
   params?: unknown[];
+
+  /** For spec compliance; handled if not provided. */
   id?: string | number;
+
+  /** For spec compliance; handled if not provided. */
   jsonrpc?: '2.0';
 }
 
-export interface JsonRpcResponse {
-  jsonrpc: '2.0';
-  id: string | number;
-  result?: unknown;
-  error?: {
+export interface SendSyncJsonRpcRequest extends JsonRpcRequest {
+  method: 'eth_accounts' | 'eth_coinbase' | 'eth_uninstallFilter' | 'net_version';
+}
+
+interface JsonRpcResponseBase {
+
+  /** Equal to the corresponding JSON-RPC request object. */
+  id?: string | number;
+
+  /** Equal to the corresponding JSON-RPC request. */
+  jsonrpc?: '2.0';
+}
+
+export interface JsonRpcErrorResponse extends JsonRpcResponseBase {
+  error: {
     code: number;
     message: string;
     data?: unknown;
   };
 }
 
-interface SendSyncJsonRpcPayload extends JsonRpcPayload {
-  method: 'eth_accounts' | 'eth_coinbase' | 'eth_uninstallFilter' | 'net_version';
+export interface JsonRpcSuccessResponse extends JsonRpcResponseBase {
+  result: unknown;
 }
+
+export type JsonRpcResponse = JsonRpcSuccessResponse | JsonRpcErrorResponse;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,70 +1,99 @@
-import { EventEmitter } from 'events'
-import { Duplex } from 'stream'
+import { EventEmitter } from 'events';
+import { Duplex } from 'stream';
 
 export interface MetamaskInpageProviderOptions {
-    /**
-     * The logging API to use.
-     * @default console
-     */
-    logger?: Pick<Console, 'log' | 'warn' | 'error' | 'debug' | 'info' | 'trace'>
-    /**
-     * The maximum number of event listeners.
-     * @default 100
-     */
-    maxEventListeners?: number
-    /**
-     * Whether the provider should send page metadata.
-     * @default true
-     */
-    shouldSendMetadata?: boolean
+
+  /**
+   * The logging API to use.
+   * @default console
+   */
+  logger?: Pick<Console, 'log' | 'warn' | 'error' | 'debug' | 'info' | 'trace'>;
+
+  /**
+   * The maximum number of event listeners.
+   * @default 100
+   */
+  maxEventListeners?: number;
+
+  /**
+   * Whether the provider should send page metadata.
+   * @default true
+   */
+  shouldSendMetadata?: boolean;
 }
+
 export class MetamaskInpageProvider extends EventEmitter {
-    /**
-     *
-     * @param connectionStream A Node.js duplex stream
-     * @param options An options bag
-     */
-    constructor(connectionStream: Duplex, options?: MetamaskInpageProviderOptions)
-    readonly isMetaMask: true
-    readonly selectedAddress: string | null
-    readonly networkVersion: string | null
-    readonly chainId: string | undefined
-    isConnected(): boolean
-    sendAsync(payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void
-    /** Submits an RPC request to MetaMask for the given method, with the given params. Resolves with the result of the method call, or rejects on error. */
-    request(args: JsonRpcPayload): Promise<unknown>
+
+  /**
+   *
+   * @param connectionStream A Node.js duplex stream
+   * @param options An options bag
+   */
+  constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions)
+
+  readonly isMetaMask: true;
+
+  readonly selectedAddress: string | null;
+
+  readonly networkVersion: string | null;
+
+  readonly chainId: string | undefined;
+
+  isConnected (): boolean
+
+  sendAsync (payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void
+
+  /**
+   * Submits an RPC request to MetaMask for the given method, with the given params.
+   * Resolves with the result of the method call, or rejects on error.
+   */
+  request (args: RequestArguments): Promise<unknown>
 }
+
 /**
  * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
  * @returns The initialized provider (whether set or not).
  */
-export function initProvider(
-    opts?: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
-        /** A Node.js duplex stream */
-        connectionStream?: Duplex
-        /** Whether the provider should be set as window.ethereum */
-        shouldSetOnWindow?: boolean
-    }
-): MetamaskInpageProvider
+export function initProvider (
+  opts?: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
+
+    /** A Node.js duplex stream */
+    connectionStream?: Duplex;
+
+    /** Whether the provider should be set as window.ethereum */
+    shouldSetOnWindow?: boolean;
+  }
+): MetamaskInpageProvider;
+
 /**
  * Sets the given provider instance as window.ethereum and dispatches the 'ethereum#initialized' event on window.
  *
  * @param providerInstance - The provider instance.
  */
-export function setGlobalProvider(providerInstance: MetamaskInpageProvider): void
-export interface JsonRpcPayload {
-    jsonrpc: string
-    method: string
-    params?: unknown[]
-    id?: string | number
+export function setGlobalProvider (providerInstance: MetamaskInpageProvider): void;
+
+export interface RequestArguments {
+  method: string;
+  params?: unknown[];
 }
+
+/**
+ * The jsonrpc and id properties will be handled if not provided.
+ */
+export interface JsonRpcPayload {
+  method: string;
+  params?: unknown[];
+  id?: string | number;
+  jsonrpc?: '2.0';
+}
+
 export interface JsonRpcResponse {
-    jsonrpc: string
-    id: string | number
-    result?: unknown
-    error?: {
-        code: number
-        message: string
-        data?: unknown
-    }
+  jsonrpc: '2.0';
+  id: string | number;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,11 +25,32 @@ export interface MetamaskInpageProviderOptions {
 export class MetamaskInpageProvider extends EventEmitter {
 
   /**
-   *
    * @param connectionStream A Node.js duplex stream
    * @param options An options bag
    */
   constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions);
+
+  isConnected (): boolean;
+
+  /**
+   * Submits an RPC request to MetaMask for the given method, with the given params.
+   * Resolves with the result of the method call, or rejects on error.
+   */
+  request (args: RequestArguments): Promise<unknown>;
+
+  sendAsync (
+    payload: JsonRpcPayload,
+    callback: (error: Error | null, result?: JsonRpcResponse) => void,
+  ): void;
+
+  send (method: string, params?: unknown[]): Promise<JsonRpcResponse>;
+
+  send (
+    payload: JsonRpcPayload,
+    callback: (error: Error | null, result?: JsonRpcResponse) => void,
+  ): void;
+
+  send (payload: SendSyncJsonRpcPayload): JsonRpcResponse;
 
   readonly isMetaMask: true;
 
@@ -38,19 +59,6 @@ export class MetamaskInpageProvider extends EventEmitter {
   readonly networkVersion: string | null;
 
   readonly chainId: string | undefined;
-
-  isConnected (): boolean;
-
-  sendAsync (
-    payload: JsonRpcPayload,
-    callback: (error: Error | null, result?: JsonRpcResponse) => void,
-  ): void;
-
-  /**
-   * Submits an RPC request to MetaMask for the given method, with the given params.
-   * Resolves with the result of the method call, or rejects on error.
-   */
-  request (args: RequestArguments): Promise<unknown>;
 }
 
 /**
@@ -100,4 +108,8 @@ export interface JsonRpcResponse {
     message: string;
     data?: unknown;
   };
+}
+
+interface SendSyncJsonRpcPayload extends JsonRpcPayload {
+  method: 'eth_accounts' | 'eth_coinbase' | 'eth_uninstallFilter' | 'net_version';
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ export class MetamaskInpageProvider extends EventEmitter {
    * @param connectionStream A Node.js duplex stream
    * @param options An options bag
    */
-  constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions)
+  constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions);
 
   readonly isMetaMask: true;
 
@@ -39,15 +39,18 @@ export class MetamaskInpageProvider extends EventEmitter {
 
   readonly chainId: string | undefined;
 
-  isConnected (): boolean
+  isConnected (): boolean;
 
-  sendAsync (payload: JsonRpcPayload, callback: (error: Error | null, result?: JsonRpcResponse) => void): void
+  sendAsync (
+    payload: JsonRpcPayload,
+    callback: (error: Error | null, result?: JsonRpcResponse) => void,
+  ): void;
 
   /**
    * Submits an RPC request to MetaMask for the given method, with the given params.
    * Resolves with the result of the method call, or rejects on error.
    */
-  request (args: RequestArguments): Promise<unknown>
+  request (args: RequestArguments): Promise<unknown>;
 }
 
 /**
@@ -66,7 +69,8 @@ export function initProvider (
 ): MetamaskInpageProvider;
 
 /**
- * Sets the given provider instance as window.ethereum and dispatches the 'ethereum#initialized' event on window.
+ * Sets the given provider instance as window.ethereum and dispatches
+ * the 'ethereum#initialized' event on window.
  *
  * @param providerInstance - The provider instance.
  */

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,12 +101,15 @@ export class MetamaskInpageProvider extends EventEmitter {
  * @returns The initialized provider (whether set or not).
  */
 export function initProvider (
-  opts: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
+  options: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
 
     /** A Node.js duplex stream. */
     connectionStream: Duplex;
 
-    /** Whether the provider should be set as window.ethereum. */
+    /**
+     * Whether the provider should be set as window.ethereum.
+     * @default true
+     */
     shouldSetOnWindow?: boolean;
   }
 ): MetamaskInpageProvider;

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,10 +66,10 @@ export class MetamaskInpageProvider extends EventEmitter {
  * @returns The initialized provider (whether set or not).
  */
 export function initProvider (
-  opts?: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
+  opts: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
 
     /** A Node.js duplex stream */
-    connectionStream?: Duplex;
+    connectionStream: Duplex;
 
     /** Whether the provider should be set as window.ethereum */
     shouldSetOnWindow?: boolean;

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -36,11 +36,11 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
 
   /**
    * @param {Object} connectionStream - A Node.js duplex stream
-   * @param {Object} opts - An options bag
-   * @param {ConsoleLike} [opts.logger] - The logging API to use. Default: console
-   * @param {number} [opts.maxEventListeners] - The maximum number of event
+   * @param {Object} options - An options bag
+   * @param {ConsoleLike} [options.logger] - The logging API to use. Default: console
+   * @param {number} [options.maxEventListeners] - The maximum number of event
    * listeners. Default: 100
-   * @param {boolean} [opts.shouldSendMetadata] - Whether the provider should
+   * @param {boolean} [options.shouldSendMetadata] - Whether the provider should
    * send page metadata. Default: true
    */
   constructor (

--- a/src/MetamaskInpageProvider.js
+++ b/src/MetamaskInpageProvider.js
@@ -266,14 +266,14 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   //====================
 
   /**
-   * Returns whether the inpage provider is connected to MetaMask.
+   * Returns whether the provider can process RPC requests.
    */
   isConnected () {
     return this._state.isConnected
   }
 
   /**
-   * Submits an RPC request to MetaMask for the given method, with the given params.
+   * Submits an RPC request for the given method, with the given params.
    * Resolves with the result of the method call, or rejects on error.
    *
    * @param {Object} args - The RPC request arguments.
@@ -319,7 +319,7 @@ module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
-   * Submit a JSON-RPC request object and a callback to make an RPC method call.
+   * Submits an RPC request per the given JSON-RPC request object.
    *
    * @param {Object} payload - The RPC request object.
    * @param {Function} cb - The callback function.

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -1,15 +1,15 @@
 const MetamaskInpageProvider = require('./MetamaskInpageProvider')
 
 /**
-   * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
-   *
-   * @param {Object} options - An options bag.
-   * @param {Object} options.connectionStream - A Node.js stream.
-   * @param {number} options.maxEventListeners - The maximum number of event listeners.
-   * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
-   * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
-   * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
-   */
+ * Initializes a MetamaskInpageProvider and (optionally) assigns it as window.ethereum.
+ *
+ * @param {Object} options - An options bag.
+ * @param {Object} options.connectionStream - A Node.js stream.
+ * @param {number} options.maxEventListeners - The maximum number of event listeners.
+ * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
+ * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
+ * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
+ */
 function initProvider ({
   connectionStream,
   maxEventListeners = 100,

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -3,11 +3,11 @@ const MetamaskInpageProvider = require('./MetamaskInpageProvider')
 /**
    * Initializes a MetamaskInpageProvider and (optionally) sets it on window.ethereum.
    *
-   * @param {Object} opts - An options bag.
-   * @param {Object} opts.connectionStream - A Node.js stream.
-   * @param {number} opts.maxEventListeners - The maximum number of event listeners.
-   * @param {boolean} opts.shouldSendMetadata - Whether the provider should send page metadata.
-   * @param {boolean} opts.shouldSetOnWindow - Whether the provider should be set as window.ethereum
+   * @param {Object} options - An options bag.
+   * @param {Object} options.connectionStream - A Node.js stream.
+   * @param {number} options.maxEventListeners - The maximum number of event listeners.
+   * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
+   * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
    * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
    */
 function initProvider ({


### PR DESCRIPTION
- Add full docstrings to declarations file
  - The docstrings in the JavaScript source are not picked up by TypeScript, at least in VS Code.
  - Make minor edits to source docstrings in process.
- Add typings for all `send` method signatures
- Use `RequestArguments` interface for `request` method
- Require `opts.connectionStream` param for `initProvider`
- Update `jsonrpc` property on `JsonRpcRequest` and `JsonRpcResponse` interfaces
- Update `JsonRpcResponse` interface to type with either `result` or `error` property
- Lint types (per our config, but without adding dependencies)
  - Basically adds spacing and semicolons