### PR TITLE
Use @metamask/eslint-config@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "safe-event-emitter": "^1.0.1"
   },
   "devDependencies": {
-    "@metamask/eslint-config": "^3.0.0",
+    "@metamask/eslint-config": "^3.1.0",
     "@types/jest": "^26.0.5",
     "eslint": "^6.8.0",
     "eslint-plugin-import": "^2.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,10 +484,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@metamask/eslint-config@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.0.0.tgz#39c4275e440cfc690524d328a0bda8227bd69326"
-  integrity sha512-AYnNopj+K0YyWuCXY4mflgMQzIcm/Jc+HiXzBzY8SJ3fMlnBXjQjsbu0B78zxLR9HZ2uW9IrCj0VG7hMj1b4og==
+"@metamask/eslint-config@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
+  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"


### PR DESCRIPTION
This PR updates the `@metamask/eslint-config` dependency to the latest published version, v3.1.0.