### PR TITLE
Fix require-clean-git script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --ext js,json --fix",
     "prepublishOnly": "yarn require-clean-git && yarn lint && yarn test",
-    "require-clean-git": "git diff --quiet || echo 'Please clean the working directory.' && exit 1"
+    "require-clean-git": "git diff --quiet || (echo 'Please clean the working directory.' && exit 1)"
   },
   "author": "MetaMask",
   "license": "MIT",


### PR DESCRIPTION
The `require-clean-git` script exited with `1` even if `git diff --clean` exited with `0`. This PR parenthesizes the `&&` operands in that script to avoid this problem.