### PR TITLE
Fix MetaMask casing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { Duplex } from 'stream';
 
-export interface MetamaskInpageProviderOptions {
+export interface MetaMaskInpageProviderOptions {
 
   /**
    * The logging API to use.
@@ -22,13 +22,13 @@ export interface MetamaskInpageProviderOptions {
   shouldSendMetadata?: boolean;
 }
 
-export class MetamaskInpageProvider extends EventEmitter {
+export class MetaMaskInpageProvider extends EventEmitter {
 
   /**
    * @param connectionStream - A Node.js duplex stream.
    * @param options - An options bag.
    */
-  constructor (connectionStream: Duplex, options?: MetamaskInpageProviderOptions);
+  constructor (connectionStream: Duplex, options?: MetaMaskInpageProviderOptions);
 
   /**
    * Returns whether the provider can process RPC requests.
@@ -97,11 +97,11 @@ export class MetamaskInpageProvider extends EventEmitter {
 }
 
 /**
- * Initializes a MetamaskInpageProvider and (optionally) assigns it as window.ethereum.
+ * Initializes a MetaMaskInpageProvider and (optionally) assigns it as window.ethereum.
  * @returns The initialized provider (whether set or not).
  */
 export function initProvider (
-  options: Pick<MetamaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
+  options: Pick<MetaMaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
 
     /** A Node.js duplex stream. */
     connectionStream: Duplex;
@@ -112,7 +112,7 @@ export function initProvider (
      */
     shouldSetOnWindow?: boolean;
   }
-): MetamaskInpageProvider;
+): MetaMaskInpageProvider;
 
 /**
  * Sets the given provider instance as window.ethereum and dispatches
@@ -120,7 +120,7 @@ export function initProvider (
  *
  * @param providerInstance - The provider instance.
  */
-export function setGlobalProvider (providerInstance: MetamaskInpageProvider): void;
+export function setGlobalProvider (providerInstance: MetaMaskInpageProvider): void;
 
 export interface RequestArguments {
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-const MetamaskInpageProvider = require('./src/MetamaskInpageProvider')
+const MetaMaskInpageProvider = require('./src/MetaMaskInpageProvider')
 const { initProvider, setGlobalProvider } = require('./src/initProvider')
 
 module.exports = {
-  MetamaskInpageProvider,
+  MetaMaskInpageProvider,
   initProvider,
   setGlobalProvider,
 }

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -32,7 +32,7 @@ let log
  * @property {function} warn - Like console.warn
  */
 
-module.exports = class MetamaskInpageProvider extends SafeEventEmitter {
+module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
   /**
    * @param {Object} connectionStream - A Node.js duplex stream

--- a/src/initProvider.js
+++ b/src/initProvider.js
@@ -1,14 +1,14 @@
-const MetamaskInpageProvider = require('./MetamaskInpageProvider')
+const MetaMaskInpageProvider = require('./MetaMaskInpageProvider')
 
 /**
- * Initializes a MetamaskInpageProvider and (optionally) assigns it as window.ethereum.
+ * Initializes a MetaMaskInpageProvider and (optionally) assigns it as window.ethereum.
  *
  * @param {Object} options - An options bag.
  * @param {Object} options.connectionStream - A Node.js stream.
  * @param {number} options.maxEventListeners - The maximum number of event listeners.
  * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
  * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
- * @returns {MetamaskInpageProvider | Proxy} The initialized provider (whether set or not).
+ * @returns {MetaMaskInpageProvider | Proxy} The initialized provider (whether set or not).
  */
 function initProvider ({
   connectionStream,
@@ -17,7 +17,7 @@ function initProvider ({
   shouldSetOnWindow = true,
 } = {}) {
 
-  let provider = new MetamaskInpageProvider(
+  let provider = new MetaMaskInpageProvider(
     connectionStream, { shouldSendMetadata, maxEventListeners },
   )
 
@@ -36,7 +36,7 @@ function initProvider ({
  * Sets the given provider instance as window.ethereum and dispatches the
  * 'ethereum#initialized' event on window.
  *
- * @param {MetamaskInpageProvider} providerInstance - The provider instance.
+ * @param {MetaMaskInpageProvider} providerInstance - The provider instance.
  */
 function setGlobalProvider (providerInstance) {
   window.ethereum = providerInstance

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,7 +52,7 @@ const getRpcPromiseCallback = (resolve, reject, unwrapResult = true) => (error, 
  * @param {Error} err - The associated error to log.
  */
 function logStreamDisconnectWarning (log, remoteLabel, err) {
-  let warningMsg = `MetamaskInpageProvider - lost connection to ${remoteLabel}`
+  let warningMsg = `MetaMaskInpageProvider - lost connection to ${remoteLabel}`
   if (err) {
     warningMsg += `\n${err.stack}`
   }

--- a/test/MetaMaskInpageProvider.misc.test.js
+++ b/test/MetaMaskInpageProvider.misc.test.js
@@ -1,9 +1,9 @@
-const MetamaskInpageProvider = require('../src/MetamaskInpageProvider')
+const MetaMaskInpageProvider = require('../src/MetaMaskInpageProvider')
 const messages = require('../src/messages')
 
 const MockDuplexStream = require('./mocks/DuplexStream')
 
-describe('MetamaskInpageProvider: Miscellanea', () => {
+describe('MetaMaskInpageProvider: Miscellanea', () => {
 
   describe('constructor', () => {
 
@@ -16,26 +16,26 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
     })
 
     it('succeeds if stream is provided', () => {
-      expect(() => new MetamaskInpageProvider(new MockDuplexStream())).not.toThrow()
+      expect(() => new MetaMaskInpageProvider(new MockDuplexStream())).not.toThrow()
     })
 
     it('succeeds if stream and valid options are provided', () => {
       const stream = new MockDuplexStream()
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           maxEventListeners: 10,
         }),
       ).not.toThrow()
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           shouldSendMetadata: false,
         }),
       ).not.toThrow()
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           maxEventListeners: 10,
           shouldSendMetadata: false,
         }),
@@ -44,15 +44,15 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
 
     it('throws if no or invalid stream is provided', () => {
       expect(
-        () => new MetamaskInpageProvider(),
+        () => new MetaMaskInpageProvider(),
       ).toThrow(messages.errors.invalidDuplexStream())
 
       expect(
-        () => new MetamaskInpageProvider('foo'),
+        () => new MetaMaskInpageProvider('foo'),
       ).toThrow(messages.errors.invalidDuplexStream())
 
       expect(
-        () => new MetamaskInpageProvider({}),
+        () => new MetaMaskInpageProvider({}),
       ).toThrow(messages.errors.invalidDuplexStream())
     })
 
@@ -60,18 +60,18 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
       const stream = new MockDuplexStream()
 
       expect(
-        () => new MetamaskInpageProvider(stream, null),
+        () => new MetaMaskInpageProvider(stream, null),
       ).toThrow('Cannot destructure property `logger` of \'undefined\' or \'null\'')
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           maxEventListeners: 10,
           shouldSendMetadata: 'foo',
         }),
       ).toThrow(messages.errors.invalidOptions(10, 'foo'))
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           maxEventListeners: 'foo',
           shouldSendMetadata: true,
         }),
@@ -90,7 +90,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
       }
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           logger: customLogger,
         }),
       ).not.toThrow()
@@ -100,7 +100,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
       const stream = new MockDuplexStream()
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           logger: 'foo',
         }),
       ).toThrow(messages.errors.invalidLoggerObject())
@@ -118,7 +118,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
       }
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           logger: customLogger,
         }),
       ).toThrow(messages.errors.invalidLoggerMethod('warn'))
@@ -136,7 +136,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
       }
 
       expect(
-        () => new MetamaskInpageProvider(stream, {
+        () => new MetaMaskInpageProvider(stream, {
           logger: customLogger,
         }),
       ).toThrow(messages.errors.invalidLoggerMethod('warn'))
@@ -147,7 +147,7 @@ describe('MetamaskInpageProvider: Miscellanea', () => {
     it('returns isConnected state', () => {
 
       jest.useFakeTimers()
-      const provider = new MetamaskInpageProvider(new MockDuplexStream())
+      const provider = new MetaMaskInpageProvider(new MockDuplexStream())
       provider.autoRefreshOnNetworkChange = false
 
       expect(

--- a/test/MetaMaskInpageProvider.rpc.test.js
+++ b/test/MetaMaskInpageProvider.rpc.test.js
@@ -1,4 +1,4 @@
-const MetamaskInpageProvider = require('../src/MetamaskInpageProvider')
+const MetaMaskInpageProvider = require('../src/MetaMaskInpageProvider')
 const messages = require('../src/messages')
 
 const MockDuplexStream = require('./mocks/DuplexStream')
@@ -8,14 +8,14 @@ const MOCK_ERROR_MESSAGE = 'Did you specify a mock return value?'
 function initProvider () {
   jest.useFakeTimers()
   const mockStream = new MockDuplexStream()
-  const provider = new MetamaskInpageProvider(mockStream)
+  const provider = new MetaMaskInpageProvider(mockStream)
   provider.mockStream = mockStream
   provider.autoRefreshOnNetworkChange = false
   jest.runAllTimers()
   return provider
 }
 
-describe('MetamaskInpageProvider: RPC', () => {
+describe('MetaMaskInpageProvider: RPC', () => {
 
   // mocking the underlying stream, and testing the basic functionality of
   // .reqest, .sendAsync, and .send


### PR DESCRIPTION
`s/Metamask/MetaMask/g`

Fixes MetaMask camel casing for everything: files, exports, variables etc.

A bit frivolous, perhaps, but the Brand demands it.