### PR TITLE
Remove web3-related functionality

### DIFF
--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -90,7 +90,6 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
         },
         // misc
         // TODO:deprecation:remove
-        autoRefresh: false,
         publicConfigStore: false,
       },
       isConnected: undefined,
@@ -105,7 +104,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
     this.networkVersion = null
     this.chainId = null
 
-    // bind functions (to prevent e.g. web3@1.x from making unbound calls)
+    // bind functions (to prevent consumers from making unbound calls)
     this._handleAccountsChanged = this._handleAccountsChanged.bind(this)
     this._handleDisconnect = this._handleDisconnect.bind(this)
     this._sendSync = this._sendSync.bind(this)
@@ -232,24 +231,6 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
     // indicate that we've connected, for EIP-1193 compliance
     setTimeout(() => this.emit('connect', { chainId: this.chainId }))
-
-    // TODO:deprecation:remove
-    /** @deprecated */
-    this._web3Ref = undefined
-
-    // TODO:deprecation:remove
-    // if true, MetaMask reloads the page if window.web3 has been accessed
-    /** @deprecated */
-    this.autoRefreshOnNetworkChange = true
-
-    // TODO:deprecation:remove
-    // wait a second to attempt to send this, so that the warning can be silenced
-    setTimeout(() => {
-      if (this.autoRefreshOnNetworkChange && !this._state.sentWarnings.autoRefresh) {
-        log.warn(messages.warnings.autoRefreshDeprecation)
-        this._state.sentWarnings.autoRefresh = true
-      }
-    }, 1000)
   }
 
   get publicConfigStore () {
@@ -473,18 +454,6 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
       // handle selectedAddress
       if (this.selectedAddress !== _accounts[0]) {
         this.selectedAddress = _accounts[0] || null
-      }
-
-      // TODO:deprecation:remove
-      // handle web3
-      if (this._web3Ref) {
-        this._web3Ref.defaultAccount = this.selectedAddress
-      } else if (
-        window.web3 &&
-        window.web3.eth &&
-        typeof window.web3.eth === 'object'
-      ) {
-        window.web3.eth.defaultAccount = this.selectedAddress
       }
 
       // only emit the event once all state has been updated

--- a/src/initializeProvider.js
+++ b/src/initializeProvider.js
@@ -22,7 +22,8 @@ function initializeProvider ({
   )
 
   provider = new Proxy(provider, {
-    deleteProperty: () => true, // some libraries, e.g. web3@1.x, mess with our API
+    // some common libraries, e.g. web3@1.x, mess with our API
+    deleteProperty: () => true,
   })
 
   if (shouldSetOnWindow) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -2,7 +2,7 @@ module.exports = {
   errors: {
     disconnected: () => `MetaMask: Lost connection to MetaMask background process.`,
     sendSiteMetadata: () => `MetaMask: Failed to send site metadata. This is an internal error, please report this bug.`,
-    unsupportedSync: (method) => `MetaMask: The MetaMask Web3 object does not support synchronous methods like ${method} without a callback parameter.`,
+    unsupportedSync: (method) => `MetaMask: The MetaMask Ethereum provider does not support synchronous methods like ${method} without a callback parameter.`,
     invalidDuplexStream: () => 'Must provide a Node.js-style duplex stream.',
     invalidOptions: (maxEventListeners, shouldSendMetadata) => `Invalid options. Received: { maxEventListeners: ${maxEventListeners}, shouldSendMetadata: ${shouldSendMetadata} }`,
     invalidRequestArgs: () => `Expected a single, non-array, object argument.`,
@@ -12,8 +12,6 @@ module.exports = {
     invalidLoggerMethod: (method) => `'args.logger' must include required method '${method}'.`,
   },
   warnings: {
-    // TODO:deprecation:remove
-    autoRefreshDeprecation: `MetaMask: MetaMask will soon stop reloading pages on network change.\nFor more information, see: https://docs.metamask.io/guide/ethereum-provider.html#ethereum-autorefreshonnetworkchange \nSet 'ethereum.autoRefreshOnNetworkChange' to 'false' to silence this warning.`,
     // deprecated methods
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
     sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and may be removed in the future. Please use 'ethereum.sendAsync(...)' or 'ethereum.request(...)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,


### PR DESCRIPTION
_Note:_ CI became detached. Check here for status: https://app.circleci.com/pipelines/github/MetaMask/inpage-provider?branch=web3-removal

This PR removes all web3-related functionality. It now lives in `@metamask/legacy-web3`.