### PR TITLE
Document type dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ initProvider({
 const { ethereum } = window
 ```
 
+### Types
+
+Types are exposed at `index.d.ts`.
+They require Node.js `EventEmitter` and `Duplex` stream types, which you can grab from e.g. [`@types/node`](https://npmjs.com/package/@types/node).
+
 ### Do Not Modify the Provider
 
 The Provider object should not be mutated by consumers under any circumstances.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+// You may have to bring your own Node types (e.g. @types/node) for these imports.
 import { EventEmitter } from 'events';
 import { Duplex } from 'stream';
 


### PR DESCRIPTION
Documents type dependencies since we're not shipping `@types/node`.