### PR TITLE
Replace public config store with RPC methods/notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^2.1.1",
     "obj-multiplex": "^1.0.0",
-    "obs-store": "^4.0.3",
     "pump": "^3.0.0",
     "safe-event-emitter": "^1.0.1"
   },

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -152,12 +152,12 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
     jsonRpcConnection.events.on('notification', (payload) => {
       const { method, params, result } = payload
 
-      if (method === 'wallet_accountsChanged') {
+      if (method === 'metamask_accountsChanged') {
         this._handleAccountsChanged(result)
 
-      } else if (method === 'wallet_unlockStateChanged') {
+      } else if (method === 'metamask_unlockStateChanged') {
         this._handleUnlockStateChanged(result)
-      } else if (method === 'wallet_chainChanged') {
+      } else if (method === 'metamask_chainChanged') {
         this._handleChainChanged(result)
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
         this.emit('notification', payload) // deprecated
@@ -304,14 +304,14 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
   /**
    * Constructor helper.
-   * Populates initial state by calling 'wallet_getProviderState' and
+   * Populates initial state by calling 'metamask_getProviderState' and
    * 'eth_accounts', and emits necessary events.
    *
    * @private
    */
   _initializeState () {
     Promise.all([
-      this.request({ method: 'wallet_getProviderState' }),
+      this.request({ method: 'metamask_getProviderState' }),
       this.request({ method: 'eth_accounts' }),
     ])
       .then(([state, accounts]) => {

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -457,8 +457,8 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
    */
   _handleChainChanged ({ chainId, networkVersion } = {}) {
     if (
-      typeof chainId !== 'string' || !chainId.startsWith('0x') ||
-      typeof networkVersion !== 'string'
+      !chainId || typeof chainId !== 'string' || !chainId.startsWith('0x') ||
+      !networkVersion || typeof networkVersion !== 'string'
     ) {
       log.error(
         'MetaMask: Received invalid network parameters. Please report this bug.',
@@ -467,10 +467,12 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
       return
     }
 
-    if (chainId !== this.chainId || networkVersion !== this.networkVersion) {
+    if (chainId !== this.chainId) {
       this.chainId = chainId
       this.emit('chainChanged', this.chainId)
+    }
 
+    if (networkVersion !== this.networkVersion) {
       this.networkVersion = networkVersion
       this.emit('networkChanged', this.networkVersion)
     }

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -88,6 +88,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
       accounts: null,
       isConnected: false,
       isUnlocked: false,
+      initialized: false,
     }
 
     this._metamask = this._getExperimentalApi()
@@ -331,6 +332,9 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
         'MetaMask: Failed to get initial state. Please report this bug.',
         error,
       )
+    } finally {
+      this._state.initialized = true
+      this.emit('_initialized')
     }
   }
 
@@ -535,6 +539,11 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
          * @returns {Promise<boolean>} - Promise resolving to true if MetaMask is currently unlocked
          */
         isUnlocked: async () => {
+          if (!this._state.initialized) {
+            await new Promise((resolve) => {
+              this.on('_initialized', () => resolve())
+            })
+          }
           return this._state.isUnlocked
         },
 

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -304,36 +304,34 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
   /**
    * Constructor helper.
-   * Populates initial state by calling 'metamask_getProviderState' and
-   * 'eth_accounts', and emits necessary events.
+   * Populates initial state by calling 'metamask_getProviderState' and emits
+   * necessary events.
    *
    * @private
    */
-  _initializeState () {
-    Promise.all([
-      this.request({ method: 'metamask_getProviderState' }),
-      this.request({ method: 'eth_accounts' }),
-    ])
-      .then(([state, accounts]) => {
-        const {
-          chainId,
-          networkVersion,
-          isUnlocked,
-        } = state
-
-        // indicate that we've connected, for EIP-1193 compliance
-        this.emit('connect', { chainId })
-
-        this._handleChainChanged({ chainId, networkVersion })
-        this._handleUnlockStateChanged(isUnlocked)
-        this._handleAccountsChanged(accounts)
+  async _initializeState () {
+    try {
+      const {
+        accounts,
+        chainId,
+        isUnlocked,
+        networkVersion,
+      } = await this.request({
+        method: 'metamask_getProviderState',
       })
-      .catch((error) => {
-        log.error(
-          'MetaMask: Failed to get initial state. Please report this bug.',
-          error,
-        )
-      })
+
+      // indicate that we've connected, for EIP-1193 compliance
+      this.emit('connect', { chainId })
+
+      this._handleChainChanged({ chainId, networkVersion })
+      this._handleUnlockStateChanged(isUnlocked)
+      this._handleAccountsChanged(accounts)
+    } catch (error) {
+      log.error(
+        'MetaMask: Failed to get initial state. Please report this bug.',
+        error,
+      )
+    }
   }
 
   /**

--- a/src/messages.js
+++ b/src/messages.js
@@ -24,6 +24,5 @@ module.exports = {
     },
     // misc
     experimentalMethods: `MetaMask: 'ethereum._metamask' exposes non-standard, experimental methods. They may be removed or changed without warning.`,
-    publicConfigStore: `MetaMask: The property 'publicConfigStore' is deprecated and WILL be removed in the future.`,
   },
 }

--- a/src/siteMetadata.js
+++ b/src/siteMetadata.js
@@ -18,7 +18,7 @@ async function sendSiteMetadata (engine, log) {
     // call engine.handle directly to avoid normal RPC request handling
     engine.handle(
       {
-        method: 'wallet_sendDomainMetadata',
+        method: 'metamask_sendDomainMetadata',
         domainMetadata,
       },
       NOOP,

--- a/test/MetaMaskInpageProvider.misc.test.js
+++ b/test/MetaMaskInpageProvider.misc.test.js
@@ -152,7 +152,7 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
 
       expect(
         provider.isConnected(),
-      ).toBeUndefined()
+      ).toBe(false)
 
       provider._state.isConnected = true
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3191,16 +3191,6 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-obs-store@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/obs-store/-/obs-store-4.0.3.tgz#b632ec7814baa604fae084a4c97e87c0b7a6d14c"
-  integrity sha512-+mm13kCRDv6IcvUDKTw0LIy5+dQhIktYaR/RwwZUFzOTi/fjMaNBnk42Adb94qZqJ00qWkjhQSZH7MXlKnTi8A==
-  dependencies:
-    readable-stream "^2.2.2"
-    safe-event-emitter "^1.0.1"
-    through2 "^2.0.3"
-    xtend "^4.0.1"
-
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3499,7 +3489,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@~2.3.6:
+readable-stream@^2.3.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -4120,14 +4110,6 @@ throat@^5.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
 
-through2@^2.0.3:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
-  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
-  dependencies:
-    readable-stream "~2.3.6"
-    xtend "~4.0.1"
-
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -4502,11 +4484,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xtend@^4.0.1, xtend@~4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
-  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
- Deletes the public config stream, `_publicConfigStore`, and `publicConfigStore` getter
- Gets state previously received through public config stream with RPC method and notifications
  - New RPC Methods
    - `wallet_getProviderState`
  - New RPC Notifications
    - `wallet_unlockStateChanged`
    - `wallet_chainChanged`

Corresponding PR in extension: https://github.com/MetaMask/metamask-extension/pull/8640

CI: https://app.circleci.com/pipelines/github/MetaMask/inpage-provider?branch=delete-public-config