### PR TITLE
Add web3 shim

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const MetaMaskInpageProvider = require('./src/MetaMaskInpageProvider')
 const { initializeProvider, setGlobalProvider } = require('./src/initializeProvider')
+const shimWeb3 = require('./src/shimWeb3')
 
 module.exports = {
-  MetaMaskInpageProvider,
   initializeProvider,
+  MetaMaskInpageProvider,
   setGlobalProvider,
+  shimWeb3,
 }

--- a/src/initializeProvider.js
+++ b/src/initializeProvider.js
@@ -1,4 +1,5 @@
 const MetaMaskInpageProvider = require('./MetaMaskInpageProvider')
+const shimWeb3 = require('./shimWeb3')
 
 /**
  * Initializes a MetaMaskInpageProvider and (optionally) assigns it as window.ethereum.
@@ -7,7 +8,8 @@ const MetaMaskInpageProvider = require('./MetaMaskInpageProvider')
  * @param {Object} options.connectionStream - A Node.js stream.
  * @param {number} options.maxEventListeners - The maximum number of event listeners.
  * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
- * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
+ * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum.
+ * @param {boolean} options.shouldShimWeb3 - Whether a window.web3 shim should be injected.
  * @returns {MetaMaskInpageProvider | Proxy} The initialized provider (whether set or not).
  */
 function initializeProvider ({
@@ -15,6 +17,7 @@ function initializeProvider ({
   maxEventListeners = 100,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
+  shouldShimWeb3 = false,
 } = {}) {
 
   let provider = new MetaMaskInpageProvider(
@@ -28,6 +31,10 @@ function initializeProvider ({
 
   if (shouldSetOnWindow) {
     setGlobalProvider(provider)
+  }
+
+  if (shouldShimWeb3) {
+    shimWeb3(provider)
   }
 
   return provider

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -25,11 +25,17 @@ module.exports = function shimWeb3 (provider) {
           }
           return Reflect.get(target, property, ...args)
         },
+        set: (...args) => {
+          console.warn(
+            'You are accessing the MetaMask window.web3 shim. This object is deprecated; use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
+          )
+          return Reflect.set(...args)
+        },
       },
     )
 
     Object.defineProperty(window, 'web3', {
-      value: Object.freeze(web3Shim),
+      value: web3Shim,
       enumerable: false,
       configurable: true,
       writable: true,

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -1,0 +1,38 @@
+/**
+ * If no existing window.web3 is found, this function injects a web3 "shim" to
+ * not break dapps that rely on window.web3.currentProvider.
+ *
+ * @param {import('./MetaMaskInpageProvider')} provider - The provider to set as window.web3.currentProvider.
+ */
+module.exports = function shimWeb3 (provider) {
+  if (!window.web3) {
+    const SHIM_IDENTIFIER = '__isMetaMaskShim__'
+    const web3Shim = new Proxy(
+      {
+        currentProvider: provider,
+        [SHIM_IDENTIFIER]: true,
+      },
+      {
+        get: (target, property, ...args) => {
+          if (property === 'currentProvider') {
+            console.warn(
+              'You are accessing the MetaMask window.web3.currentProvider shim. Just use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
+            )
+          } else if (property !== SHIM_IDENTIFIER) {
+            console.error(
+              `MetaMask no longer injects web3. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3`,
+            )
+          }
+          return Reflect.get(target, property, ...args)
+        },
+      },
+    )
+
+    Object.defineProperty(window, 'web3', {
+      value: Object.freeze(web3Shim),
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    })
+  }
+}

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -16,7 +16,7 @@ module.exports = function shimWeb3 (provider) {
         get: (target, property, ...args) => {
           if (property === 'currentProvider') {
             console.warn(
-              'You are accessing the MetaMask window.web3.currentProvider shim. Just use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
+              'You are accessing the MetaMask window.web3.currentProvider shim. This property is deprecated; use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
             )
           } else if (property !== SHIM_IDENTIFIER) {
             console.error(


### PR DESCRIPTION
Adds a function for shimming `window.web3.currentProvider`, which `initProvider` can be configured to call.