### PR TITLE
Rename initProvider to initializeProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ not suitable for out-of-the-box use with other wallets.
 ## Usage
 
 ```javascript
-import { initProvider } from '@metamask/inpage-provider'
+import { initializeProvider } from '@metamask/inpage-provider'
 
 // Create a stream to a remote provider:
 const metamaskStream = new LocalMessageDuplexStream({
@@ -20,7 +20,7 @@ const metamaskStream = new LocalMessageDuplexStream({
 })
 
 // this will initialize the provider and set it as window.ethereum
-initProvider({
+initializeProvider({
   connectionStream: metamaskStream,
 })
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ export class MetaMaskInpageProvider extends EventEmitter {
  * Initializes a MetaMaskInpageProvider and (optionally) assigns it as window.ethereum.
  * @returns The initialized provider (whether set or not).
  */
-export function initProvider (
+export function initializeProvider (
   options: Pick<MetaMaskInpageProviderOptions, 'maxEventListeners' | 'shouldSendMetadata'> & {
 
     /** A Node.js duplex stream. */

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 const MetaMaskInpageProvider = require('./src/MetaMaskInpageProvider')
-const { initProvider, setGlobalProvider } = require('./src/initProvider')
+const { initializeProvider, setGlobalProvider } = require('./src/initializeProvider')
 
 module.exports = {
   MetaMaskInpageProvider,
-  initProvider,
+  initializeProvider,
   setGlobalProvider,
 }

--- a/src/initializeProvider.js
+++ b/src/initializeProvider.js
@@ -10,7 +10,7 @@ const MetaMaskInpageProvider = require('./MetaMaskInpageProvider')
  * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum
  * @returns {MetaMaskInpageProvider | Proxy} The initialized provider (whether set or not).
  */
-function initProvider ({
+function initializeProvider ({
   connectionStream,
   maxEventListeners = 100,
   shouldSendMetadata = true,
@@ -44,6 +44,6 @@ function setGlobalProvider (providerInstance) {
 }
 
 module.exports = {
-  initProvider,
+  initializeProvider,
   setGlobalProvider,
 }

--- a/test/MetaMaskInpageProvider.rpc.test.js
+++ b/test/MetaMaskInpageProvider.rpc.test.js
@@ -5,7 +5,7 @@ const MockDuplexStream = require('./mocks/DuplexStream')
 
 const MOCK_ERROR_MESSAGE = 'Did you specify a mock return value?'
 
-function initProvider () {
+function initializeProvider () {
   jest.useFakeTimers()
   const mockStream = new MockDuplexStream()
   const provider = new MetaMaskInpageProvider(mockStream)
@@ -35,7 +35,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
 
     beforeEach(() => {
       resetRpcEngineResponseMock()
-      provider = initProvider()
+      provider = initializeProvider()
       jest.spyOn(provider, '_handleAccountsChanged').mockImplementation()
       jest.spyOn(provider._rpcEngine, 'handle').mockImplementation(
         (_payload, cb) => cb(...mockRpcEngineResponse()),
@@ -245,7 +245,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
 
     beforeEach(() => {
       resetRpcRequestResponseMock()
-      provider = initProvider()
+      provider = initializeProvider()
       jest.spyOn(provider, '_rpcRequest').mockImplementation(
         (_payload, cb, _isInternal) => cb(...mockRpcRequestResponse()),
       )
@@ -354,7 +354,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
 
     beforeEach(() => {
       resetRpcEngineResponseMock()
-      provider = initProvider()
+      provider = initializeProvider()
       jest.spyOn(provider, '_handleAccountsChanged').mockImplementation()
       jest.spyOn(provider._rpcEngine, 'handle').mockImplementation(
         (_payload, cb) => cb(...mockRpcEngineResponse()),
@@ -473,7 +473,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
 
     beforeEach(() => {
       resetRpcRequestResponseMock()
-      provider = initProvider()
+      provider = initializeProvider()
       jest.spyOn(provider, '_rpcRequest').mockImplementation(
         (_payload, cb, _isInternal) => cb(...mockRpcRequestResponse()),
       )


### PR DESCRIPTION
This is purely cosmetic. Renames all strings and files named "initProvider" to "initializeProvider".

Down with useless contractions.