### PR TITLE
Prevent web3 shim identifier from being overwritten

### DIFF
--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -9,7 +9,7 @@ module.exports = function shimWeb3 (provider) {
     const SHIM_IDENTIFIER = '__isMetaMaskShim__'
 
     let web3Shim = { currentProvider: provider }
-    Object.defineProperty(object, SHIM_IDENTIFIER, {
+    Object.defineProperty(web3Shim, SHIM_IDENTIFIER, {
       value: true,
       enumerable: true,
       configurable: false,
@@ -17,7 +17,7 @@ module.exports = function shimWeb3 (provider) {
     })
 
     web3Shim = new Proxy(
-      object,
+      web3Shim,
       {
         get: (target, property, ...args) => {
           if (property === 'currentProvider') {

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -7,11 +7,17 @@
 module.exports = function shimWeb3 (provider) {
   if (!window.web3) {
     const SHIM_IDENTIFIER = '__isMetaMaskShim__'
-    const web3Shim = new Proxy(
-      {
-        currentProvider: provider,
-        [SHIM_IDENTIFIER]: true,
-      },
+
+    let web3Shim = { currentProvider: provider }
+    Object.defineProperty(object, SHIM_IDENTIFIER, {
+      value: true,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    })
+
+    web3Shim = new Proxy(
+      object,
       {
         get: (target, property, ...args) => {
           if (property === 'currentProvider') {


### PR DESCRIPTION
Protect `web3.__isMetaMaskShim__` by means of `Object.defineProperty`.