### PR TITLE
Add logger argument to initializeProvider, log web3 shim usage

### DIFF
--- a/src/initializeProvider.js
+++ b/src/initializeProvider.js
@@ -14,6 +14,7 @@ const shimWeb3 = require('./shimWeb3')
  */
 function initializeProvider ({
   connectionStream,
+  logger = console,
   maxEventListeners = 100,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
@@ -21,7 +22,7 @@ function initializeProvider ({
 } = {}) {
 
   let provider = new MetaMaskInpageProvider(
-    connectionStream, { shouldSendMetadata, maxEventListeners },
+    connectionStream, { logger, maxEventListeners, shouldSendMetadata },
   )
 
   provider = new Proxy(provider, {
@@ -34,7 +35,7 @@ function initializeProvider ({
   }
 
   if (shouldShimWeb3) {
-    shimWeb3(provider)
+    shimWeb3(provider, logger)
   }
 
   return provider

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -3,8 +3,9 @@
  * not break dapps that rely on window.web3.currentProvider.
  *
  * @param {import('./MetaMaskInpageProvider')} provider - The provider to set as window.web3.currentProvider.
+ * @param {typeof console} log - The logging API to use.
  */
-module.exports = function shimWeb3 (provider) {
+module.exports = function shimWeb3 (provider, log = console) {
   if (!window.web3) {
     const SHIM_IDENTIFIER = '__isMetaMaskShim__'
 
@@ -21,20 +22,22 @@ module.exports = function shimWeb3 (provider) {
       {
         get: (target, property, ...args) => {
           if (property === 'currentProvider') {
-            console.warn(
+            log.warn(
               'You are accessing the MetaMask window.web3.currentProvider shim. This property is deprecated; use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
             )
           } else if (property !== SHIM_IDENTIFIER) {
-            console.error(
+            log.error(
               `MetaMask no longer injects web3. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3`,
             )
             provider.request({ method: 'metamask_logWeb3ShimUsage' })
-              .catch(() => undefined)
+              .catch((error) => {
+                log.debug('MetaMask: Failed to log web3 shim usage.', error)
+              })
           }
           return Reflect.get(target, property, ...args)
         },
         set: (...args) => {
-          console.warn(
+          log.warn(
             'You are accessing the MetaMask window.web3 shim. This object is deprecated; use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
           )
           return Reflect.set(...args)

--- a/src/shimWeb3.js
+++ b/src/shimWeb3.js
@@ -28,6 +28,8 @@ module.exports = function shimWeb3 (provider) {
             console.error(
               `MetaMask no longer injects web3. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3`,
             )
+            provider.request({ method: 'metamask_logWeb3ShimUsage' })
+              .catch(() => undefined)
           }
           return Reflect.get(target, property, ...args)
         },


### PR DESCRIPTION
- Add `logger` argument to `initializeProvider`
  - This is now passed on to the pre-existing `logger` argument of the inpage provider constructor
- Calls the `metamask_logWeb3ShimUsage` RPC method whenever a property other than the shim id/flag or `currentProvider` is accessed.
  - The RPC method is implemented here: https://github.com/MetaMask/metamask-extension/pull/9156