### PR TITLE
Only emit state change events after initialization

### DIFF
--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -532,6 +532,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
         this.selectedAddress = _accounts[0] || null
       }
 
+      // finally, after all state has been updated, emit the event
       if (this._state.initialized) {
         this.emit('accountsChanged', _accounts)
       }

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -438,8 +438,10 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
         this.selectedAddress = _accounts[0] || null
       }
 
-      // only emit the event once all state has been updated
-      this.emit('accountsChanged', _accounts)
+      if (this._state.initialized) {
+        // only emit the event once all state has been updated
+        this.emit('accountsChanged', _accounts)
+      }
     }
   }
 
@@ -469,12 +471,16 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
     if (chainId !== this.chainId) {
       this.chainId = chainId
-      this.emit('chainChanged', this.chainId)
+      if (this._state.initialized) {
+        this.emit('chainChanged', this.chainId)
+      }
     }
 
     if (networkVersion !== this.networkVersion) {
       this.networkVersion = networkVersion
-      this.emit('networkChanged', this.networkVersion)
+      if (this._state.initialized) {
+        this.emit('networkChanged', this.networkVersion)
+      }
     }
   }
 


### PR DESCRIPTION
It was reported in #110 that `chainChanged` (and by extension, `networkChanged`) is sometimes emitted for the first time after page load, causing a reload loop for those handling chain changes by reloading the page. When the `chainId` is set on initialization, the chain has not changed, and `chainChanged` should not be emitted. The same can be said for `accountsChanged`, which currently would emit under the same circumstances.

This PR ensures that `chainChanged`, `networkChanged`, and `accountsChanged` are only emitted after the provider has been initialized.

Fixes #110 