### PR TITLE
Ensure metadata is sent even if document is already fully loaded

### DIFF
--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -174,11 +174,15 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
 
     // send website metadata
     if (shouldSendMetadata) {
-      const domContentLoadedHandler = () => {
+      if (document.readyState === 'complete') {
         sendSiteMetadata(this._rpcEngine, this._log)
-        window.removeEventListener('DOMContentLoaded', domContentLoadedHandler)
+      } else {
+        const domContentLoadedHandler = () => {
+          sendSiteMetadata(this._rpcEngine, this._log)
+          window.removeEventListener('DOMContentLoaded', domContentLoadedHandler)
+        }
+        window.addEventListener('DOMContentLoaded', domContentLoadedHandler)
       }
-      window.addEventListener('DOMContentLoaded', domContentLoadedHandler)
     }
 
     // indicate that we've connected, for EIP-1193 compliance


### PR DESCRIPTION
The metadata sending functionality assumed synchronous injection, which we shouldn't. This PR ensures metadata is sent event if the page is already fully loaded when the constructor runs.