### PR TITLE
Implement connectivity events correctly

### DIFF
--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -381,7 +381,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
     if (!this._state.isConnected) {
       this._state.isConnected = true
       this.emit('connect', { chainId })
-      log.debug(messages.info.connected(chainId))
+      this._log.debug(messages.info.connected(chainId))
     }
   }
 
@@ -404,13 +404,13 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
           1013, // Try again later
           errorMessage || messages.errors.disconnected(),
         )
-        log.debug(error)
+        this._log.debug(error)
       } else {
         error = new EthereumRpcError(
           1011, // Internal error
           errorMessage || messages.errors.permanentlyDisconnected(),
         )
-        log.error(error)
+        this._log.error(error)
         this.chainId = null
         this.networkVersion = null
         this._state.accounts = null
@@ -431,7 +431,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
    * @emits MetamaskInpageProvider#disconnect
    */
   _handleStreamDisconnect (streamName, error) {
-    logStreamDisconnectWarning(log, streamName, error, this)
+    logStreamDisconnectWarning(this._log, streamName, error, this)
     this._handleDisconnect(false, error ? error.message : undefined)
   }
 
@@ -452,7 +452,7 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
       !chainId || typeof chainId !== 'string' || !chainId.startsWith('0x') ||
       !networkVersion || typeof networkVersion !== 'string'
     ) {
-      log.error(
+      this._log.error(
         'MetaMask: Received invalid network parameters. Please report this bug.',
         { chainId, networkVersion },
       )

--- a/src/MetaMaskInpageProvider.js
+++ b/src/MetaMaskInpageProvider.js
@@ -374,6 +374,9 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
+   * When the provider becomes connected, updates internal state and emits
+   * required events. Idempotent.
+   *
    * @param {string} chainId - The ID of the newly connected chain.
    * @emits MetaMaskInpageProvider#connect
    */
@@ -386,7 +389,12 @@ module.exports = class MetaMaskInpageProvider extends SafeEventEmitter {
   }
 
   /**
+   * When the provider becomes disconnected, updates internal state and emits
+   * required events. Idempotent with respect to the isRecoverable parameter.
+   *
+   * Error codes per the CloseEvent status codes as required by EIP-1193:
    * https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes
+   *
    * @param {boolean} isRecoverable - Whether the disconnection is recoverable.
    * @param {string} [errorMessage] - A custom error message.
    * @emits MetaMaskInpageProvider#disconnect

--- a/src/initializeProvider.js
+++ b/src/initializeProvider.js
@@ -6,14 +6,16 @@ const shimWeb3 = require('./shimWeb3')
  *
  * @param {Object} options - An options bag.
  * @param {Object} options.connectionStream - A Node.js stream.
- * @param {number} options.maxEventListeners - The maximum number of event listeners.
- * @param {boolean} options.shouldSendMetadata - Whether the provider should send page metadata.
- * @param {boolean} options.shouldSetOnWindow - Whether the provider should be set as window.ethereum.
- * @param {boolean} options.shouldShimWeb3 - Whether a window.web3 shim should be injected.
+ * @param {string} [options.jsonRpcStreamName] - The name of the internal JSON-RPC stream.
+ * @param {number} [options.maxEventListeners] - The maximum number of event listeners.
+ * @param {boolean} [options.shouldSendMetadata] - Whether the provider should send page metadata.
+ * @param {boolean} [options.shouldSetOnWindow] - Whether the provider should be set as window.ethereum.
+ * @param {boolean} [options.shouldShimWeb3] - Whether a window.web3 shim should be injected.
  * @returns {MetaMaskInpageProvider | Proxy} The initialized provider (whether set or not).
  */
 function initializeProvider ({
   connectionStream,
+  jsonRpcStreamName,
   logger = console,
   maxEventListeners = 100,
   shouldSendMetadata = true,
@@ -22,7 +24,13 @@ function initializeProvider ({
 } = {}) {
 
   let provider = new MetaMaskInpageProvider(
-    connectionStream, { logger, maxEventListeners, shouldSendMetadata },
+    connectionStream,
+    {
+      logger,
+      jsonRpcStreamName,
+      maxEventListeners,
+      shouldSendMetadata,
+    },
   )
 
   provider = new Proxy(provider, {

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,7 +1,7 @@
 module.exports = {
   errors: {
     disconnected: () => 'MetaMask: Disconnected from chain. Attempting to connect.',
-    permanentlyDisconnected: () => 'MetaMask: Provider permanently disconnected. Page reload required.',
+    permanentlyDisconnected: () => 'MetaMask: Disconnected from MetaMask background. Page reload required.',
     sendSiteMetadata: () => `MetaMask: Failed to send site metadata. This is an internal error, please report this bug.`,
     unsupportedSync: (method) => `MetaMask: The MetaMask Ethereum provider does not support synchronous methods like ${method} without a callback parameter.`,
     invalidDuplexStream: () => 'Must provide a Node.js-style duplex stream.',

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,6 +1,7 @@
 module.exports = {
   errors: {
-    disconnected: () => `MetaMask: Lost connection to MetaMask background process.`,
+    disconnected: () => 'MetaMask: Disconnected from chain. Attempting to connect.',
+    permanentlyDisconnected: () => 'MetaMask: Provider permanently disconnected. Page reload required.',
     sendSiteMetadata: () => `MetaMask: Failed to send site metadata. This is an internal error, please report this bug.`,
     unsupportedSync: (method) => `MetaMask: The MetaMask Ethereum provider does not support synchronous methods like ${method} without a callback parameter.`,
     invalidDuplexStream: () => 'Must provide a Node.js-style duplex stream.',
@@ -10,6 +11,9 @@ module.exports = {
     invalidRequestParams: () => `'args.params' must be an object or array if provided.`,
     invalidLoggerObject: () => `'args.logger' must be an object if provided.`,
     invalidLoggerMethod: (method) => `'args.logger' must include required method '${method}'.`,
+  },
+  info: {
+    connected: (chainId) => `MetaMask: Connected to chain with ID "${chainId}".`,
   },
   warnings: {
     // deprecated methods

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,4 @@
-const EventEmitter = require('events')
 const { ethErrors } = require('eth-rpc-errors')
-const SafeEventEmitter = require('safe-event-emitter')
 
 // utility functions
 
@@ -44,28 +42,26 @@ const getRpcPromiseCallback = (resolve, reject, unwrapResult = true) => (error, 
 }
 
 /**
- * Logs a stream disconnection error. Emits an 'error' if bound to an
+ * Logs a stream disconnection error. Emits an 'error' if given an
  * EventEmitter that has listeners for the 'error' event.
  *
- * @param {Object} log - The logging API to use.
+ * @param {typeof console} log - The logging API to use.
  * @param {string} remoteLabel - The label of the disconnected stream.
- * @param {Error} err - The associated error to log.
+ * @param {Error} [err] - The associated error to log.
+ * @param {import('safe-event-emitter')} [emitter] - The logging API to use.
  */
-function logStreamDisconnectWarning (log, remoteLabel, err) {
-  let warningMsg = `MetaMaskInpageProvider - lost connection to ${remoteLabel}`
-  if (err) {
+function logStreamDisconnectWarning (log, remoteLabel, err, emitter) {
+  let warningMsg = `MetaMask: Lost connection to "${remoteLabel}".`
+  if (err && err.stack) {
     warningMsg += `\n${err.stack}`
   }
   log.warn(warningMsg)
-  if (this instanceof EventEmitter || this instanceof SafeEventEmitter) {
-    if (this.listenerCount('error') > 0) {
-      this.emit('error', warningMsg)
-    }
+  if (emitter && emitter.listenerCount('error') > 0) {
+    emitter.emit('error', warningMsg)
   }
 }
 
-// eslint-disable-next-line no-empty-function
-const NOOP = () => {}
+const NOOP = () => undefined
 
 // constants
 

--- a/test/MetaMaskInpageProvider.misc.test.js
+++ b/test/MetaMaskInpageProvider.misc.test.js
@@ -61,7 +61,7 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
 
       expect(
         () => new MetaMaskInpageProvider(stream, null),
-      ).toThrow('Cannot destructure property `logger` of \'undefined\' or \'null\'')
+      ).toThrow('Cannot destructure property `jsonRpcStreamName` of \'undefined\' or \'null\'')
 
       expect(
         () => new MetaMaskInpageProvider(stream, {


### PR DESCRIPTION
This PR correctly implements connectivity events per [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193). Previously, `connect` was only emitted correctly by accident, while `disconnect` was always correct when emitted, but was only emitted for a subset of cases.

Corresponding extension PR: https://github.com/MetaMask/metamask-extension/pull/10006

Fixes #61, Closes #65 