### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/extension-devs
+*                                    @MetaMask/devs


### PR DESCRIPTION
This is a cross-product package, and the owners should be `MetaMask/devs`.