### PR TITLE
Restore `data` provider event

### DIFF
--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -267,13 +267,16 @@ export default class MetaMaskInpageProvider extends SafeEventEmitter {
       } else if (method === 'metamask_chainChanged') {
         this._handleChainChanged(params);
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
+        // deprecated
+        // emitted here because that was the original order
+        this.emit('data', payload);
+
         this.emit('message', {
           type: method,
           data: params,
         });
 
         // deprecated
-        this.emit('data', payload);
         this.emit('notification', payload.params.result);
       } else if (method === 'METAMASK_STREAM_FAILURE') {
         connectionStream.destroy(

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -267,6 +267,9 @@ export default class MetaMaskInpageProvider extends SafeEventEmitter {
       } else if (method === 'metamask_chainChanged') {
         this._handleChainChanged(params);
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
+        // deprecated
+        this.emit('data', payload);
+
         this.emit('message', {
           type: method,
           data: params,

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -267,15 +267,13 @@ export default class MetaMaskInpageProvider extends SafeEventEmitter {
       } else if (method === 'metamask_chainChanged') {
         this._handleChainChanged(params);
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {
-        // deprecated
-        this.emit('data', payload);
-
         this.emit('message', {
           type: method,
           data: params,
         });
 
         // deprecated
+        this.emit('data', payload);
         this.emit('notification', payload.params.result);
       } else if (method === 'METAMASK_STREAM_FAILURE') {
         connectionStream.destroy(

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -21,10 +21,10 @@ const messages = {
     sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and may be removed in the future. Please use 'ethereum.sendAsync(...)' or 'ethereum.request(...)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
     // deprecated events
     events: {
-      close: `MetaMask: The event 'close' is deprecated and may be removed in the future. Please use 'disconnect' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
-      data: `MetaMask: The event 'data' is deprecated and may be removed in the future.`,
-      networkChanged: `MetaMask: The event 'networkChanged' is deprecated and may be removed in the future. Please use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
-      notification: `MetaMask: The event 'notification' is deprecated and may be removed in the future. Please use 'message' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,
+      close: `MetaMask: The event 'close' is deprecated and may be removed in the future. Please use 'disconnect' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193#disconnect`,
+      data: `MetaMask: The event 'data' is deprecated and will be removed in the future. Use 'message' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193#message`,
+      networkChanged: `MetaMask: The event 'networkChanged' is deprecated and may be removed in the future. Use 'chainChanged' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193#chainchanged`,
+      notification: `MetaMask: The event 'notification' is deprecated and may be removed in the future. Use 'message' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193#message`,
     },
     // misc
     experimentalMethods: `MetaMask: 'ethereum._metamask' exposes non-standard, experimental methods. They may be removed or changed without warning.`,


### PR DESCRIPTION
This event is deprecated, and is not part of EIP-1193. However we did not plan to remove this; it was removed accidentally as part of #109. It should now behave exactly as it did in v6.3.0.

The text of the deprecation warning for this event has also been updated to provide a recommended alternative.