### PR TITLE
v8.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.0.3] - 2021-01-20
+
+### Fixed
+
+- Restore 'data' provider event ([#135](https://github.com/MetaMask/inpage-provider/pull/135))
+
 ## [8.0.2] - 2021-01-12
 
 ### Changed
@@ -202,7 +208,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   added deprecation warnings for them ([#30](https://github.com/MetaMask/inpage-provider/pull/30))
 - Un-deprecated `sendAsync` ([#29](https://github.com/MetaMask/inpage-provider/pull/29))
 
-[Unreleased]:https://github.com/MetaMask/inpage-provider/compare/v8.0.1...HEAD
+[Unreleased]:https://github.com/MetaMask/inpage-provider/compare/v8.0.3...HEAD
+[8.0.3]:https://github.com/MetaMask/inpage-provider/compare/v8.0.2...v8.0.3
+[8.0.2]:https://github.com/MetaMask/inpage-provider/compare/v8.0.1...v8.0.2
 [8.0.1]:https://github.com/MetaMask/inpage-provider/compare/v8.0.0...v8.0.1
 [8.0.0]:https://github.com/MetaMask/inpage-provider/compare/v7.0.0...v8.0.0
 [7.0.0]:https://github.com/MetaMask/inpage-provider/compare/v6.3.0...v7.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/inpage-provider",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "A JavaScript Ethereum provider that connects to the wallet over a stream.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixed:

- Restore 'data' provider event ([#135](https://github.com/MetaMask/inpage-provider/pull/135))