### PR TITLE
Fix warning on second `currentProvider` access

### DIFF
--- a/src/shimWeb3.ts
+++ b/src/shimWeb3.ts
@@ -35,7 +35,7 @@ export default function shimWeb3(
             log.warn(
               'You are accessing the MetaMask window.web3.currentProvider shim. This property is deprecated; use window.ethereum instead. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3',
             );
-          } else if (property !== SHIM_IDENTIFIER && !loggedMissingProperty) {
+          } else if (property !== 'currentProvider' && property !== SHIM_IDENTIFIER && !loggedMissingProperty) {
             loggedMissingProperty = true;
             log.error(
               `MetaMask no longer injects web3. For details, see: https://docs.metamask.io/guide/provider-migration.html#replacing-window-web3`,


### PR DESCRIPTION
We expose the `currentProvider` property on our shim as a deprecated way to access to provider, to make the task of migrating dapps away from our injected web3 instance easier. The intent was to warn if that property is used, but log an error to the console and inform MetaMask if any other property is used.

There was a mistake in the logic that caused us to treat subsequent accesses to `currentProvider` to be treated like some unsupported property was being accessed. This results in the console error being shown erroneously, it bloats our web3 usage metrics, and it causes the warning about web3 usage to appear unnecessarily in the MetaMask UI.

The logic has been updated to never treat `currentProvider` as an unsupported property. Accessing that property will only result in a deprecation warning.