### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,7 @@ export class MetaMaskInpageProvider extends EventEmitter {
 
   /**
    * Submits an RPC request per the given JSON-RPC request object.
+   * @deprecated Use {@link request} instead.
    */
   sendAsync(
     payload: JsonRpcRequest<unknown>,


### PR DESCRIPTION
sendAsync was deprecated.
It was described in EIP-1193.
https://eips.ethereum.org/EIPS/eip-1193#sendasync-deprecated