### PR TITLE
fix: _handleChainChanged in MetaMaskInpageProvider to handle networkVersion

### DIFF
--- a/src/BaseProvider.rpc.test.ts
+++ b/src/BaseProvider.rpc.test.ts
@@ -309,4 +309,24 @@ describe('BaseProvider: RPC', () => {
       });
     });
   });
+  describe('provider events', () => {
+    // eslint-disable-next-line jest/no-test-callback
+    it('calls chainChanged when it chainId changes ', (done) => {
+      const mockStream = new MockDuplexStream();
+      const p = new BaseProvider(mockStream);
+      (p as any)._state.initialized = true;
+      p.on('chainChanged', (changed) => {
+        expect(changed).toBeDefined();
+        done();
+      });
+      mockStream.push({
+        name: 'metamask-provider',
+        data: {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x1' },
+        },
+      });
+    });
+  });
 });

--- a/src/BaseProvider.rpc.test.ts
+++ b/src/BaseProvider.rpc.test.ts
@@ -310,22 +310,23 @@ describe('BaseProvider: RPC', () => {
     });
   });
   describe('provider events', () => {
-    // eslint-disable-next-line jest/no-test-callback
-    it('calls chainChanged when it chainId changes ', (done) => {
+    it('calls chainChanged when it chainId changes ', async () => {
       const mockStream = new MockDuplexStream();
-      const p = new BaseProvider(mockStream);
-      (p as any)._state.initialized = true;
-      p.on('chainChanged', (changed) => {
-        expect(changed).toBeDefined();
-        done();
-      });
-      mockStream.push({
-        name: 'metamask-provider',
-        data: {
-          jsonrpc: '2.0',
-          method: 'metamask_chainChanged',
-          params: { chainId: '0x1' },
-        },
+      const baseProvider = new BaseProvider(mockStream);
+      (baseProvider as any)._state.initialized = true;
+      await new Promise((resolve) => {
+        baseProvider.on('chainChanged', (changed) => {
+          expect(changed).toBeDefined();
+          resolve(undefined);
+        });
+        mockStream.push({
+          name: 'metamask-provider',
+          data: {
+            jsonrpc: '2.0',
+            method: 'metamask_chainChanged',
+            params: { chainId: '0x1', networkVersion: '0x1' },
+          },
+        });
       });
     });
   });

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -420,21 +420,32 @@ export default class BaseProvider extends SafeEventEmitter {
    */
   protected _handleChainChanged({
     chainId,
+    networkVersion,
   }: { chainId?: string; networkVersion?: string } = {}) {
-    if (!chainId || typeof chainId !== 'string' || !chainId.startsWith('0x')) {
+    if (
+      !chainId ||
+      typeof chainId !== 'string' ||
+      !chainId.startsWith('0x') ||
+      !networkVersion ||
+      typeof networkVersion !== 'string'
+    ) {
       this._log.error(
         'MetaMask: Received invalid network parameters. Please report this bug.',
-        { chainId },
+        { chainId, networkVersion },
       );
       return;
     }
 
-    this._handleConnect(chainId);
+    if (networkVersion === 'loading') {
+      this._handleDisconnect(true);
+    } else {
+      this._handleConnect(chainId);
 
-    if (chainId !== this.chainId) {
-      this.chainId = chainId;
-      if (this._state.initialized) {
-        this.emit('chainChanged', this.chainId);
+      if (chainId !== this.chainId) {
+        this.chainId = chainId;
+        if (this._state.initialized) {
+          this.emit('chainChanged', this.chainId);
+        }
       }
     }
   }

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -420,32 +420,21 @@ export default class BaseProvider extends SafeEventEmitter {
    */
   protected _handleChainChanged({
     chainId,
-    networkVersion,
   }: { chainId?: string; networkVersion?: string } = {}) {
-    if (
-      !chainId ||
-      typeof chainId !== 'string' ||
-      !chainId.startsWith('0x') ||
-      !networkVersion ||
-      typeof networkVersion !== 'string'
-    ) {
+    if (!chainId || typeof chainId !== 'string' || !chainId.startsWith('0x')) {
       this._log.error(
         'MetaMask: Received invalid network parameters. Please report this bug.',
-        { chainId, networkVersion },
+        { chainId },
       );
       return;
     }
 
-    if (networkVersion === 'loading') {
-      this._handleDisconnect(true);
-    } else {
-      this._handleConnect(chainId);
+    this._handleConnect(chainId);
 
-      if (chainId !== this.chainId) {
-        this.chainId = chainId;
-        if (this._state.initialized) {
-          this.emit('chainChanged', this.chainId);
-        }
+    if (chainId !== this.chainId) {
+      this.chainId = chainId;
+      if (this._state.initialized) {
+        this.emit('chainChanged', this.chainId);
       }
     }
   }

--- a/src/MetaMaskInpageProvider.rpc.test.ts
+++ b/src/MetaMaskInpageProvider.rpc.test.ts
@@ -636,41 +636,45 @@ describe('MetaMaskInpageProvider: RPC', () => {
       );
     });
   });
+
   describe('provider events', () => {
-    // eslint-disable-next-line jest/no-test-callback
-    it('calls chainChanged when it chainId changes ', (done) => {
+    it('calls chainChanged when it chainId changes ', async () => {
       const mockStream = new MockDuplexStream();
-      const p = new MetaMaskInpageProvider(mockStream);
-      (p as any)._state.initialized = true;
-      p.on('chainChanged', (changed) => {
-        expect(changed).toBe('0x1');
-        done();
-      });
-      mockStream.push({
-        name: 'metamask-provider',
-        data: {
-          jsonrpc: '2.0',
-          method: 'metamask_chainChanged',
-          params: { chainId: '0x1', networkVersion: '0x1' },
-        },
+      const inpageProvider = new MetaMaskInpageProvider(mockStream);
+      (inpageProvider as any)._state.initialized = true;
+      await new Promise((resolve) => {
+        inpageProvider.on('chainChanged', (changed) => {
+          expect(changed).toBe('0x1');
+          resolve(undefined);
+        });
+        mockStream.push({
+          name: 'metamask-provider',
+          data: {
+            jsonrpc: '2.0',
+            method: 'metamask_chainChanged',
+            params: { chainId: '0x1', networkVersion: '0x1' },
+          },
+        });
       });
     });
-    // eslint-disable-next-line jest/no-test-callback
-    it('calls networkChanged when it networkVersion changes ', (done) => {
+
+    it('calls networkChanged when it networkVersion changes ', async () => {
       const mockStream = new MockDuplexStream();
-      const p = new MetaMaskInpageProvider(mockStream);
-      (p as any)._state.initialized = true;
-      p.on('networkChanged', (changed) => {
-        expect(changed).toBe('0x1');
-        done();
-      });
-      mockStream.push({
-        name: 'metamask-provider',
-        data: {
-          jsonrpc: '2.0',
-          method: 'metamask_chainChanged',
-          params: { chainId: '0x1', networkVersion: '0x1' },
-        },
+      const inpageProvider = new MetaMaskInpageProvider(mockStream);
+      (inpageProvider as any)._state.initialized = true;
+      await new Promise((resolve) => {
+        inpageProvider.on('networkChanged', (changed) => {
+          expect(changed).toBe('0x1');
+          resolve(undefined);
+        });
+        mockStream.push({
+          name: 'metamask-provider',
+          data: {
+            jsonrpc: '2.0',
+            method: 'metamask_chainChanged',
+            params: { chainId: '0x1', networkVersion: '0x1' },
+          },
+        });
       });
     });
   });

--- a/src/MetaMaskInpageProvider.rpc.test.ts
+++ b/src/MetaMaskInpageProvider.rpc.test.ts
@@ -636,4 +636,42 @@ describe('MetaMaskInpageProvider: RPC', () => {
       );
     });
   });
+  describe('provider events', () => {
+    // eslint-disable-next-line jest/no-test-callback
+    it('calls chainChanged when it chainId changes ', (done) => {
+      const mockStream = new MockDuplexStream();
+      const p = new MetaMaskInpageProvider(mockStream);
+      (p as any)._state.initialized = true;
+      p.on('chainChanged', (changed) => {
+        expect(changed).toBe('0x1');
+        done();
+      });
+      mockStream.push({
+        name: 'metamask-provider',
+        data: {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x1', networkVersion: '0x1' },
+        },
+      });
+    });
+    // eslint-disable-next-line jest/no-test-callback
+    it('calls networkChanged when it networkVersion changes ', (done) => {
+      const mockStream = new MockDuplexStream();
+      const p = new MetaMaskInpageProvider(mockStream);
+      (p as any)._state.initialized = true;
+      p.on('networkChanged', (changed) => {
+        expect(changed).toBe('0x1');
+        done();
+      });
+      mockStream.push({
+        name: 'metamask-provider',
+        data: {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x1', networkVersion: '0x1' },
+        },
+      });
+    });
+  });
 });

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -403,6 +403,7 @@ export default class MetaMaskInpageProvider extends BaseProvider {
    * from existing values.
    *
    * @emits MetamaskInpageProvider#chainChanged
+   * @emits MetamaskInpageProvider#networkChanged
    * @param networkInfo - An object with network info.
    * @param networkInfo.chainId - The latest chain ID.
    * @param networkInfo.networkVersion - The latest network ID.

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -412,37 +412,16 @@ export default class MetaMaskInpageProvider extends BaseProvider {
     chainId,
     networkVersion,
   }: { chainId?: string; networkVersion?: string } = {}) {
+    super._handleChainChanged({ chainId, networkVersion });
+
     if (
-      !chainId ||
-      typeof chainId !== 'string' ||
-      !chainId.startsWith('0x') ||
-      !networkVersion ||
-      typeof networkVersion !== 'string'
+      networkVersion &&
+      networkVersion !== 'loading' &&
+      networkVersion !== this.networkVersion
     ) {
-      this._log.error(
-        'MetaMask: Received invalid network parameters. Please report this bug.',
-        { chainId, networkVersion },
-      );
-      return;
-    }
-
-    if (networkVersion === 'loading') {
-      this._handleDisconnect(true);
-    } else {
-      this._handleConnect(chainId);
-
-      if (chainId !== this.chainId) {
-        this.chainId = chainId;
-        if (this._state.initialized) {
-          this.emit('chainChanged', this.chainId);
-        }
-      }
-
-      if (networkVersion !== this.networkVersion) {
-        this.networkVersion = networkVersion;
-        if (this._state.initialized) {
-          this.emit('networkChanged', this.networkVersion);
-        }
+      this.networkVersion = networkVersion;
+      if (this._state.initialized) {
+        this.emit('networkChanged', this.networkVersion);
       }
     }
   }


### PR DESCRIPTION
- adds tests for the 2 events `chainChanged` and `networkChanged`