### PR TITLE
Fix 8.1.1 changelog, add publishConfig to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Package renamed to `@metamask/providers` ([#168](https://github.com/MetaMask/providers/pull/168))
+- Rename package to `@metamask/providers` ([#168](https://github.com/MetaMask/providers/pull/168))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.1.1] - 2021-05-12
 
+### Changed
+
+- Package renamed to `@metamask/providers` ([#168](https://github.com/MetaMask/providers/pull/168))
+
 ### Fixed
 
 - Restore `networkChanged` event in `MetaMaskInpageProvider` ([#171](https://github.com/MetaMask/providers/pull/171))

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "node": ">=12.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
     "build": "mkdir -p dist && rm -rf dist/* && tsc --project .",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc --project .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,14 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc --project .",
+    "build": "mkdir -p dist && rm -rf dist/* && tsc --project .",
     "test": "jest",
     "coverage": "jest --coverage",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' --single-quote --ignore-path .gitignore",
     "lint": "yarn lint:eslint && yarn lint:misc --check",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write",
-    "prepublishOnly": "yarn require-clean-git && yarn lint && yarn test",
-    "require-clean-git": "git diff --quiet || (echo 'Please clean the working directory.' && exit 1)"
+    "prepublishOnly": "yarn build && yarn lint && yarn test"
   },
   "author": "MetaMask",
   "license": "MIT",


### PR DESCRIPTION
We should probably note in the changelog that the package is renamed 🤪 

Since the package is scoped, we should also really have the appropriate `publishConfig` in the manifest. Also fixes some package.json scripts.