### PR TITLE
feat: add unlockStateChanged event for dapps

### DIFF
--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -511,7 +511,6 @@ export default class BaseProvider extends SafeEventEmitter {
    * array.
    *
    * Does nothing if the received value is equal to the existing value.
-   * There are no lock/unlock events.
    *
    * @param opts - Options bag.
    * @param opts.accounts - The exposed accounts, if any.

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -531,6 +531,7 @@ export default class BaseProvider extends SafeEventEmitter {
     if (isUnlocked !== this._state.isUnlocked) {
       this._state.isUnlocked = isUnlocked;
       this._handleAccountsChanged(accounts || []);
+      this.emit('unlockStateChanged', isUnlocked);
     }
   }
 }


### PR DESCRIPTION
https://github.com/MetaMask/metamask-extension/issues/10368

Emit unlockStateChanged event to dapps with the status of whether or not it isUnlocked.  

A use case for this event could be a dapp that needs to know whether or not the user has triggered 'lock' on metamask, and based on that event, would lock the user out of the dapp, prompting for re-login.