### PR TITLE
Fix mangled docstring in AbstractStreamProvider

### DIFF
--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -29,7 +29,8 @@ export interface JsonRpcConnection {
 /**
  * An abstract EIP-1193 provider wired to some duplex stream via a
  * `json-rpc-middleware-stream` JSON-RPC stream middleware. Implementers must
- * directly call
+ * call {@link AbstractStreamProvider._initializeStateAsync} after instantiation
+ * to initialize the provider's state.
  */
 export abstract class AbstractStreamProvider extends BaseProvider {
   protected _jsonRpcConnection: JsonRpcConnection;


### PR DESCRIPTION
I mangled the docstring somehow in #209. This PR fixes it.