### PR TITLE
Use `_handleConnect` for initial `connect` event

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,10 +20,10 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 56.19,
-      functions: 53.33,
-      lines: 58.44,
-      statements: 58.73,
+      branches: 55.75,
+      functions: 52.81,
+      lines: 58.22,
+      statements: 58.52,
     },
   },
   projects: [

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -131,11 +131,6 @@ export abstract class BaseProvider extends SafeEventEmitter {
     this._rpcRequest = this._rpcRequest.bind(this);
     this.request = this.request.bind(this);
 
-    // EIP-1193 connect, emitted in _initializeState
-    this.on('connect', () => {
-      this._state.isConnected = true;
-    });
-
     // Handle RPC requests via dapp-side RPC engine.
     //
     // ATTN: Implementers must push a middleware that hands off requests to
@@ -233,8 +228,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
       const { accounts, chainId, isUnlocked, networkVersion } = initialState;
 
       // EIP-1193 connect
-      this.emit('connect', { chainId });
-
+      this._handleConnect(chainId);
       this._handleChainChanged({ chainId, networkVersion });
       this._handleUnlockStateChanged({ accounts, isUnlocked });
       this._handleAccountsChanged(accounts);


### PR DESCRIPTION
We were basically re-implementing the logic of `_handleConnect` by setting up a listener in the `BaseProvider` constructor that we never tore down. This PR just uses the dedicated handler for the event like nature intended.