### PR TITLE
Make window.ethereum accessible via top window only by default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '/mocks/', '/test/'],
   coverageThreshold: {
     global: {
-      branches: 55.75,
+      branches: 54.78,
       functions: 52.81,
       lines: 58.22,
       statements: 58.52,

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -83,9 +83,8 @@ export function setGlobalProvider(
   providerInstance: MetaMaskInpageProvider,
   shouldSetOnFrames: boolean,
 ): void {
-  if (!shouldSetOnFrames && window !== top) {
-    return;
+  if (shouldSetOnFrames || window === top) {
+    (window as Record<string, any>).ethereum = providerInstance;
+    window.dispatchEvent(new Event('ethereum#initialized'));
   }
-  (window as Record<string, any>).ethereum = providerInstance;
-  window.dispatchEvent(new Event('ethereum#initialized'));
 }

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -61,8 +61,8 @@ export function initializeProvider({
     deleteProperty: () => true,
   });
 
-  if (shouldSetOnWindow) {
-    setGlobalProvider(proxiedProvider, shouldSetOnFrames);
+  if (shouldSetOnWindow && (shouldSetOnFrames || window === top)) {
+    setGlobalProvider(proxiedProvider);
   }
 
   if (shouldShimWeb3) {
@@ -77,14 +77,10 @@ export function initializeProvider({
  * 'ethereum#initialized' event on window.
  *
  * @param providerInstance - The provider instance.
- * @param shouldSetOnFrames - Whether the provider should be set as window.ethereum within windows that are not the top window.
  */
 export function setGlobalProvider(
   providerInstance: MetaMaskInpageProvider,
-  shouldSetOnFrames: boolean,
 ): void {
-  if (shouldSetOnFrames || window === top) {
-    (window as Record<string, any>).ethereum = providerInstance;
-    window.dispatchEvent(new Event('ethereum#initialized'));
-  }
+  (window as Record<string, any>).ethereum = providerInstance;
+  window.dispatchEvent(new Event('ethereum#initialized'));
 }

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -17,6 +17,11 @@ interface InitializeProviderOptions extends MetaMaskInpageProviderOptions {
   shouldSetOnWindow?: boolean;
 
   /**
+   * Whether the provider should be set as window.ethereum within windows that are not the top window.
+   */
+  shouldSetOnFrames?: boolean;
+
+  /**
    * Whether the window.web3 shim should be set.
    */
   shouldShimWeb3?: boolean;
@@ -41,6 +46,7 @@ export function initializeProvider({
   maxEventListeners = 100,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
+  shouldSetOnFrames = false,
   shouldShimWeb3 = false,
 }: InitializeProviderOptions): MetaMaskInpageProvider {
   const provider = new MetaMaskInpageProvider(connectionStream, {
@@ -56,7 +62,7 @@ export function initializeProvider({
   });
 
   if (shouldSetOnWindow) {
-    setGlobalProvider(proxiedProvider);
+    setGlobalProvider(proxiedProvider, shouldSetOnFrames);
   }
 
   if (shouldShimWeb3) {
@@ -71,10 +77,15 @@ export function initializeProvider({
  * 'ethereum#initialized' event on window.
  *
  * @param providerInstance - The provider instance.
+ * @param shouldSetOnFrames - Whether the provider should be set as window.ethereum within windows that are not the top window.
  */
 export function setGlobalProvider(
   providerInstance: MetaMaskInpageProvider,
+  shouldSetOnFrames: boolean,
 ): void {
+  if (!shouldSetOnFrames && window !== top) {
+    return;
+  }
   (window as Record<string, any>).ethereum = providerInstance;
   window.dispatchEvent(new Event('ethereum#initialized'));
 }


### PR DESCRIPTION
As part of an internal discussion it was decided that it's best that `window.ethereum` API will be exported via top window only (by default).

The decision is derived from the fact that when an iframe to domain X inside a webpage under domain Y communicates with MM via `window.ethereum`, MM displays the transaction's origin as X (even though the dapp's origin is Y).

As a rule of thumb (security-wise) we believe that MM should respect requests only from the domain of the dapp itself, and not from other domains that are loaded inside the dapp.

In case truly needed, we will consider creating a tool for delegation of such capabilities between top frame and child frames within a dapp (please reach out if this affects you).

> We use MM (MetaMask) just as an example, can be any other extension wallet as well)