### PR TITLE
fix accountsChanged callback loop

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,8 @@ module.exports = {
     global: {
       branches: 58.12,
       functions: 54.95,
-      lines: 60.76,
-      statements: 60.99,
+      lines: 60.61,
+      statements: 60.84,
     },
   },
   projects: [

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -417,7 +417,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
 
       // finally, after all state has been updated, emit the event
       if (this._state.initialized) {
-        const _nextAccounts = [..._accounts]
+        const _nextAccounts = [..._accounts];
         this.emit('accountsChanged', _nextAccounts);
       }
     }

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -417,7 +417,8 @@ export abstract class BaseProvider extends SafeEventEmitter {
 
       // finally, after all state has been updated, emit the event
       if (this._state.initialized) {
-        this.emit('accountsChanged', _accounts);
+        const _nextAccounts = [..._accounts]
+        this.emit('accountsChanged', _nextAccounts);
       }
     }
   }


### PR DESCRIPTION
### Reason
Change the **accountsChanged** callback object to a new object , or will cause loop.This is because the callback function of accountsChanged returns the reference of the accounts, so request **eth_accounts** after externally modifying the reference of the account will cause accountsChanged to be triggered again, then it keeps looping
### Reproducibility
If you change the result returned by **accountsChanged** and request **eth_accounts** again, you will enter a loop .
```js
  window.ethereum.on("accountsChanged", async (newAccounts) => {
    newAccounts[0] = "1234...";
    const nextAccounts = await window.ethereum.request({
      method: "eth_accounts"
    });
    console.log("nextAccounts", nextAccounts);
  });
```
### Solution
In the callback of accountsChanged, return the deep copy object