### PR TITLE
Implement EIP-6963

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,14 +34,22 @@ module.exports = {
     },
 
     {
+      files: ['EIP6963.test.ts', 'jest.setup.browser.js'],
+      rules: {
+        // We're mixing Node and browser environments in these files.
+        'no-restricted-globals': 'off',
+      },
+    },
+
+    {
       files: ['jest.setup.browser.js'],
       env: { browser: true },
+      // This file contains copypasta and we're not going to bother fixing these.
       rules: {
         'jest/require-top-level-describe': 'off',
         'jsdoc/require-description': 'off',
         'jsdoc/require-param-description': 'off',
         'jsdoc/require-param-type': 'off',
-        'no-restricted-globals': 'off',
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,11 +26,23 @@ module.exports = {
     },
 
     {
-      files: ['*.test.ts', '*.test.js'],
+      files: ['*.test.ts', '*.test.js', 'jest.setup*.js'],
       extends: [
         '@metamask/eslint-config-jest',
         '@metamask/eslint-config-nodejs',
       ],
+    },
+
+    {
+      files: ['jest.setup.browser.js'],
+      env: { browser: true },
+      rules: {
+        'jest/require-top-level-describe': 'off',
+        'jsdoc/require-description': 'off',
+        'jsdoc/require-param-description': 'off',
+        'jsdoc/require-param-type': 'off',
+        'no-restricted-globals': 'off',
+      },
     },
   ],
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,7 +46,7 @@ const baseConfig = {
   coverageThreshold: {
     global: {
       branches: 64.78,
-      functions: 66,
+      functions: 65.65,
       lines: 66.81,
       statements: 66.88,
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,8 +47,8 @@ const baseConfig = {
     global: {
       branches: 64.78,
       functions: 65.65,
-      lines: 66.81,
-      statements: 66.88,
+      lines: 66.66,
+      statements: 66.74,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 61.49,
-      functions: 62.92,
-      lines: 64.82,
-      statements: 64.95,
+      branches: 63.26,
+      functions: 63.73,
+      lines: 65.6,
+      statements: 65.7,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,8 +47,8 @@ const baseConfig = {
     global: {
       branches: 60.86,
       functions: 62.92,
-      lines: 64.82,
-      statements: 64.95,
+      lines: 64.55,
+      statements: 64.69,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 59.77,
-      functions: 60.24,
-      lines: 63.15,
-      statements: 63.33,
+      branches: 60.86,
+      functions: 62.92,
+      lines: 64.82,
+      statements: 64.95,
     },
   },
 
@@ -222,8 +222,12 @@ const browserConfig = {
   ...baseConfig,
   displayName: 'Browser Providers',
   testEnvironment: 'jsdom',
-  testMatch: ['**/*InpageProvider.test.ts', '**/*ExtensionProvider.test.ts'],
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  testMatch: [
+    '**/*InpageProvider.test.ts',
+    '**/*ExtensionProvider.test.ts',
+    '**/EIP6963.test.ts',
+  ],
+  setupFilesAfterEnv: ['./jest.setup.browser.js'],
 };
 
 module.exports = {

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 62.88,
-      functions: 63.73,
-      lines: 65.6,
-      statements: 65.7,
+      branches: 63.07,
+      functions: 64.13,
+      lines: 65.77,
+      statements: 65.87,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 60.86,
+      branches: 61.49,
       functions: 62.92,
-      lines: 64.55,
-      statements: 64.69,
+      lines: 64.82,
+      statements: 64.95,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,7 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 63.26,
+      branches: 62.88,
       functions: 63.73,
       lines: 65.6,
       statements: 65.7,

--- a/jest.setup.browser.js
+++ b/jest.setup.browser.js
@@ -1,0 +1,88 @@
+Object.assign(global, require('jest-chrome'));
+
+// Clean up jsdom between tests.
+// Courtesy @jhildenbiddle
+// https://github.com/jestjs/jest/issues/1224#issuecomment-716075260
+const sideEffects = {
+  document: {
+    addEventListener: {
+      fn: document.addEventListener,
+      refs: [],
+    },
+    keys: Object.keys(document),
+  },
+  window: {
+    addEventListener: {
+      fn: window.addEventListener,
+      refs: [],
+    },
+    keys: Object.keys(window),
+  },
+};
+
+// Lifecycle Hooks
+// -----------------------------------------------------------------------------
+beforeAll(async () => {
+  // Spy addEventListener
+  ['document', 'window'].forEach((obj) => {
+    const { fn } = sideEffects[obj].addEventListener;
+    const { refs } = sideEffects[obj].addEventListener;
+
+    /**
+     *
+     * @param type
+     * @param listener
+     * @param options
+     */
+    function addEventListenerSpy(type, listener, options) {
+      // Store listener reference so it can be removed during reset
+      refs.push({ type, listener, options });
+      // Call original window.addEventListener
+      fn(type, listener, options);
+    }
+
+    // Add to default key array to prevent removal during reset
+    sideEffects[obj].keys.push('addEventListener');
+
+    // Replace addEventListener with mock
+    global[obj].addEventListener = addEventListenerSpy;
+  });
+});
+
+// Reset JSDOM. This attempts to remove side effects from tests, however it does
+// not reset all changes made to globals like the window and document
+// objects. Tests requiring a full JSDOM reset should be stored in separate
+// files, which is only way to do a complete JSDOM reset with Jest.
+beforeEach(async () => {
+  const rootElm = document.documentElement;
+
+  // Remove attributes on root element
+  [...rootElm.attributes].forEach((attr) => rootElm.removeAttribute(attr.name));
+
+  // Remove elements (faster than setting innerHTML)
+  while (rootElm.firstChild) {
+    rootElm.removeChild(rootElm.firstChild);
+  }
+
+  // Remove global listeners and keys
+  ['document', 'window'].forEach((obj) => {
+    const { refs } = sideEffects[obj].addEventListener;
+
+    // Listeners
+    while (refs.length) {
+      const { type, listener, options } = refs.pop();
+      global[obj].removeEventListener(type, listener, options);
+    }
+
+    // This breaks coverage.
+    // // Keys
+    // Object.keys(global[obj])
+    //   .filter((key) => !sideEffects[obj].keys.includes(key))
+    //   .forEach((key) => {
+    //     delete global[obj][key];
+    //   });
+  });
+
+  // Restore base elements
+  rootElm.innerHTML = '<head></head><body></body>';
+});

--- a/jest.setup.browser.js
+++ b/jest.setup.browser.js
@@ -25,8 +25,7 @@ const sideEffects = {
 beforeAll(async () => {
   // Spy addEventListener
   ['document', 'window'].forEach((obj) => {
-    const { fn } = sideEffects[obj].addEventListener;
-    const { refs } = sideEffects[obj].addEventListener;
+    const { fn, refs } = sideEffects[obj].addEventListener;
 
     /**
      *

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,0 @@
-Object.assign(global, require('jest-chrome'));

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@metamask/object-multiplex": "^1.1.0",
     "@metamask/safe-event-emitter": "^3.0.0",
+    "@metamask/utils": "^5.0.2",
     "detect-browser": "^5.2.0",
     "eth-rpc-errors": "^4.0.2",
     "extension-port-stream": "^2.0.1",
@@ -47,6 +48,7 @@
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^4.2.1",
     "pump": "^3.0.0",
+    "uuid": "^9.0.0",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {
@@ -61,6 +63,7 @@
     "@types/node": "^17.0.23",
     "@types/pump": "^1.1.0",
     "@types/readable-stream": "^2.3.15",
+    "@types/uuid": "^9.0.1",
     "@types/webextension-polyfill": "^0.10.0",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^4.2.1",
     "pump": "^3.0.0",
-    "uuid": "^9.0.0",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-restricted-globals */
-
 import {
   announceProvider,
   requestProvider,

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -1,34 +1,27 @@
-import {
-  announceProvider,
-  requestProvider,
-  MetaMaskEIP6963ProviderInfo,
-} from './EIP6963';
+import { announceProvider, requestProvider } from './EIP6963';
+
+const getProviderInfo = () => ({
+  name: 'test',
+  icon: 'https://wallet.io/icon.svg',
+  walletId: 'testWalletId',
+  uuid: 'testUuid',
+});
 
 describe('EIP6963', () => {
-  describe('MetaMaskEIP6963ProviderInfo', () => {
-    it('has expected shape and values', () => {
-      expect(MetaMaskEIP6963ProviderInfo).toStrictEqual({
-        walletId: 'io.metamask',
-        uuid: expect.any(String),
-        name: 'MetaMask',
-        icon: 'https://raw.githubusercontent.com/MetaMask/brand-resources/cb6fd847f3a9cc5e231c749383c3898935e62eab/SVG/metamask-fox.svg',
-      });
-    });
-  });
-
   describe('announceProvider', () => {
     it('should announce a provider', () => {
-      const provider = { name: 'test' };
+      const provider: any = { name: 'test' };
+      const providerDetail = { info: getProviderInfo(), provider };
       const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
       const addEventListener = jest.spyOn(window, 'addEventListener');
 
-      announceProvider(provider as any);
+      announceProvider(providerDetail);
 
       expect(dispatchEvent).toHaveBeenCalledTimes(1);
       expect(dispatchEvent).toHaveBeenCalledWith(
         new CustomEvent('eip6963:announceProvider', {
           detail: {
-            info: MetaMaskEIP6963ProviderInfo,
+            info: getProviderInfo(),
             provider,
           },
         }),
@@ -38,51 +31,19 @@ describe('EIP6963', () => {
         'eip6963:requestProvider',
         expect.any(Function),
       );
-    });
-
-    it('should not be affected by modifying MetaMaskEIP6963ProviderInfo', () => {
-      const provider = { name: 'test' };
-      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
-      const addEventListener = jest.spyOn(window, 'addEventListener');
-
-      const { walletId } = MetaMaskEIP6963ProviderInfo;
-      (MetaMaskEIP6963ProviderInfo as any).walletId = 'foo';
-      announceProvider(provider as any);
-
-      expect(dispatchEvent).toHaveBeenCalledTimes(1);
-      expect(dispatchEvent).toHaveBeenCalledWith(
-        new CustomEvent('eip6963:announceProvider', {
-          detail: {
-            info: { ...MetaMaskEIP6963ProviderInfo, walletId },
-            provider,
-          },
-        }),
-      );
-      expect((dispatchEvent as any).mock.calls[0][0].detail).toStrictEqual({
-        info: { ...MetaMaskEIP6963ProviderInfo, walletId },
-        provider,
-      });
-
-      expect(addEventListener).toHaveBeenCalledTimes(1);
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:requestProvider',
-        expect.any(Function),
-      );
-
-      // Reset
-      (MetaMaskEIP6963ProviderInfo as any).walletId = walletId;
     });
   });
 
   describe('requestProvider', () => {
     it('should receive an announced provider (called before announceProvider)', async () => {
       const provider: any = { name: 'test' };
+      const providerDetail = { info: getProviderInfo(), provider };
       const handleProvider = jest.fn();
       const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
       const addEventListener = jest.spyOn(window, 'addEventListener');
 
       requestProvider(handleProvider);
-      announceProvider(provider);
+      announceProvider(providerDetail);
       await delay();
 
       expect(dispatchEvent).toHaveBeenCalledTimes(2);
@@ -105,18 +66,19 @@ describe('EIP6963', () => {
 
       expect(handleProvider).toHaveBeenCalledTimes(1);
       expect(handleProvider).toHaveBeenCalledWith({
-        info: MetaMaskEIP6963ProviderInfo,
+        info: getProviderInfo(),
         provider,
       });
     });
 
     it('should receive an announced provider (called after announceProvider)', async () => {
       const provider: any = { name: 'test' };
+      const providerDetail = { info: getProviderInfo(), provider };
       const handleProvider = jest.fn();
       const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
       const addEventListener = jest.spyOn(window, 'addEventListener');
 
-      announceProvider(provider);
+      announceProvider(providerDetail);
       requestProvider(handleProvider);
       await delay();
 
@@ -142,7 +104,7 @@ describe('EIP6963', () => {
 
       expect(handleProvider).toHaveBeenCalledTimes(1);
       expect(handleProvider).toHaveBeenCalledWith({
-        info: MetaMaskEIP6963ProviderInfo,
+        info: getProviderInfo(),
         provider,
       });
     });

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -4,11 +4,23 @@ const getProviderInfo = () => ({
   name: 'test',
   icon: 'https://wallet.io/icon.svg',
   walletId: 'testWalletId',
-  uuid: 'testUuid',
+  uuid: '1449211e-5560-4235-9ab1-582cbe2b165f',
 });
 
 describe('EIP6963', () => {
   describe('announceProvider', () => {
+    it('throws if the UUID is invalid', () => {
+      ['foo', null, undefined, Symbol('bar')].forEach((invalidUuid) => {
+        const provider: any = { name: 'test' };
+        const providerDetail = { info: getProviderInfo(), provider };
+        providerDetail.info.uuid = invalidUuid as any;
+
+        expect(() => announceProvider(providerDetail)).toThrow(
+          new Error('Invalid `uuid` field. Must be a v4 UUID.'),
+        );
+      });
+    });
+
     it('should announce a provider', () => {
       const provider: any = { name: 'test' };
       const providerDetail = { info: getProviderInfo(), provider };

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -7,16 +7,71 @@ const getProviderInfo = () => ({
   uuid: '1449211e-5560-4235-9ab1-582cbe2b165f',
 });
 
+const providerInfoValidationError = () =>
+  new Error(
+    'Invalid EIP-6963 provider detail. See https://eips.ethereum.org/EIPS/eip-6963 for requirements.',
+  );
+
 describe('EIP6963', () => {
   describe('announceProvider', () => {
-    it('throws if the UUID is invalid', () => {
-      ['foo', null, undefined, Symbol('bar')].forEach((invalidUuid) => {
-        const provider: any = { name: 'test' };
-        const providerDetail = { info: getProviderInfo(), provider };
-        providerDetail.info.uuid = invalidUuid as any;
+    describe('provider info validation', () => {
+      it('throws if the provider info is not a plain object', () => {
+        [null, undefined, Symbol('bar'), []].forEach((invalidInfo) => {
+          expect(() => announceProvider(invalidInfo as any)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
+      });
 
-        expect(() => announceProvider(providerDetail)).toThrow(
-          new Error('Invalid `uuid` field. Must be a v4 UUID.'),
+      it('throws if the `icon` field is invalid', () => {
+        [null, undefined, '', 'not-a-url', Symbol('bar')].forEach(
+          (invalidIcon) => {
+            const provider: any = { name: 'test' };
+            const providerDetail = { info: getProviderInfo(), provider };
+            providerDetail.info.icon = invalidIcon as any;
+
+            expect(() => announceProvider(providerDetail)).toThrow(
+              providerInfoValidationError(),
+            );
+          },
+        );
+      });
+
+      it('throws if the `name` field is invalid', () => {
+        [null, undefined, '', {}, [], Symbol('bar')].forEach((invalidName) => {
+          const provider: any = { name: 'test' };
+          const providerDetail = { info: getProviderInfo(), provider };
+          providerDetail.info.name = invalidName as any;
+
+          expect(() => announceProvider(providerDetail)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
+      });
+
+      it('throws if the `uuid` field is invalid', () => {
+        [null, undefined, '', 'foo', Symbol('bar')].forEach((invalidUuid) => {
+          const provider: any = { name: 'test' };
+          const providerDetail = { info: getProviderInfo(), provider };
+          providerDetail.info.uuid = invalidUuid as any;
+
+          expect(() => announceProvider(providerDetail)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
+      });
+
+      it('throws if the `walletId` field is invalid', () => {
+        [null, undefined, '', {}, [], Symbol('bar')].forEach(
+          (invalidWalletId) => {
+            const provider: any = { name: 'test' };
+            const providerDetail = { info: getProviderInfo(), provider };
+            providerDetail.info.walletId = invalidWalletId as any;
+
+            expect(() => announceProvider(providerDetail)).toThrow(
+              providerInfoValidationError(),
+            );
+          },
         );
       });
     });

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -99,10 +99,12 @@ describe('EIP6963', () => {
       await delay();
 
       expect(dispatchEvent).toHaveBeenCalledTimes(2);
-      expect(dispatchEvent).toHaveBeenCalledWith(
+      expect(dispatchEvent).toHaveBeenNthCalledWith(
+        1,
         new Event('eip6963:requestProvider'),
       );
-      expect(dispatchEvent).toHaveBeenCalledWith(
+      expect(dispatchEvent).toHaveBeenNthCalledWith(
+        2,
         new CustomEvent('eip6963:announceProvider'),
       );
 
@@ -137,10 +139,16 @@ describe('EIP6963', () => {
       // Notice that 3 events are dispatched in total when requestProvider is
       // called after announceProvider.
       expect(dispatchEvent).toHaveBeenCalledTimes(3);
-      expect(dispatchEvent).toHaveBeenCalledWith(
+      expect(dispatchEvent).toHaveBeenNthCalledWith(
+        1,
+        new CustomEvent('eip6963:announceProvider'),
+      );
+      expect(dispatchEvent).toHaveBeenNthCalledWith(
+        2,
         new Event('eip6963:requestProvider'),
       );
-      expect(dispatchEvent).toHaveBeenCalledWith(
+      expect(dispatchEvent).toHaveBeenNthCalledWith(
+        3,
         new CustomEvent('eip6963:announceProvider'),
       );
 

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -1,9 +1,10 @@
 import { announceProvider, requestProvider } from './EIP6963';
 
 const getProviderInfo = () => ({
-  name: 'test',
-  icon: 'https://wallet.io/icon.svg',
-  uuid: '1449211e-5560-4235-9ab1-582cbe2b165f',
+  uuid: '350670db-19fa-4704-a166-e52e178b59d2',
+  name: 'Example Wallet',
+  icon: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"/>',
+  rdns: 'com.example.wallet',
 });
 
 const providerInfoValidationError = () =>
@@ -11,7 +12,7 @@ const providerInfoValidationError = () =>
     'Invalid EIP-6963 ProviderDetail object. See https://eips.ethereum.org/EIPS/eip-6963 for requirements.',
   );
 
-describe('EIP6963', () => {
+describe('EIP-6963', () => {
   describe('announceProvider', () => {
     describe('provider info validation', () => {
       it('throws if the provider info is not a plain object', () => {

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -3,7 +3,6 @@ import { announceProvider, requestProvider } from './EIP6963';
 const getProviderInfo = () => ({
   name: 'test',
   icon: 'https://wallet.io/icon.svg',
-  walletId: 'testWalletId',
   uuid: '1449211e-5560-4235-9ab1-582cbe2b165f',
 });
 
@@ -59,20 +58,6 @@ describe('EIP6963', () => {
             providerInfoValidationError(),
           );
         });
-      });
-
-      it('throws if the `walletId` field is invalid', () => {
-        [null, undefined, '', {}, [], Symbol('bar')].forEach(
-          (invalidWalletId) => {
-            const provider: any = { name: 'test' };
-            const providerDetail = { info: getProviderInfo(), provider };
-            providerDetail.info.walletId = invalidWalletId as any;
-
-            expect(() => announceProvider(providerDetail)).toThrow(
-              providerInfoValidationError(),
-            );
-          },
-        );
       });
     });
 

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -13,200 +13,157 @@ const providerInfoValidationError = () =>
   );
 
 describe('EIP-6963', () => {
-  describe('announceProvider', () => {
-    describe('provider info validation', () => {
-      it('throws if the provider info is not a plain object', () => {
-        [null, undefined, Symbol('bar'), []].forEach((invalidInfo) => {
-          expect(() => announceProvider(invalidInfo as any)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
-      });
-
-      it('throws if the `icon` field is invalid', () => {
-        [
-          null,
-          undefined,
-          '',
-          'not-a-data-uri',
-          'https://example.com/logo.png',
-          'data:text/plain;blah',
-          Symbol('bar'),
-        ].forEach((invalidIcon) => {
-          const provider: any = { name: 'test' };
-          const providerDetail = { info: getProviderInfo(), provider };
-          providerDetail.info.icon = invalidIcon as any;
-
-          expect(() => announceProvider(providerDetail)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
-      });
-
-      it('throws if the `name` field is invalid', () => {
-        [null, undefined, '', {}, [], Symbol('bar')].forEach((invalidName) => {
-          const provider: any = { name: 'test' };
-          const providerDetail = { info: getProviderInfo(), provider };
-          providerDetail.info.name = invalidName as any;
-
-          expect(() => announceProvider(providerDetail)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
-      });
-
-      it('throws if the `uuid` field is invalid', () => {
-        [null, undefined, '', 'foo', Symbol('bar')].forEach((invalidUuid) => {
-          const provider: any = { name: 'test' };
-          const providerDetail = { info: getProviderInfo(), provider };
-          providerDetail.info.uuid = invalidUuid as any;
-
-          expect(() => announceProvider(providerDetail)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
-      });
-
-      it('throws if the `rdns` field is invalid', () => {
-        [
-          null,
-          undefined,
-          '',
-          'not-a-valid-domain',
-          '..com',
-          'com.',
-          Symbol('bar'),
-        ].forEach((invalidRdns) => {
-          const provider: any = { name: 'test' };
-          const providerDetail = { info: getProviderInfo(), provider };
-          providerDetail.info.rdns = invalidRdns as any;
-
-          expect(() => announceProvider(providerDetail)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
+  describe('provider info validation', () => {
+    it('throws if the provider info is not a plain object', () => {
+      [null, undefined, Symbol('bar'), []].forEach((invalidInfo) => {
+        expect(() => announceProvider(invalidInfo as any)).toThrow(
+          providerInfoValidationError(),
+        );
       });
     });
 
-    describe('provider validation', () => {
-      it('throws if the provider is not a plain object', () => {
-        [null, undefined, Symbol('bar'), []].forEach((invalidProvider) => {
-          const provider: any = invalidProvider;
-          const providerDetail = { info: getProviderInfo(), provider };
+    it('throws if the `icon` field is invalid', () => {
+      [
+        null,
+        undefined,
+        '',
+        'not-a-data-uri',
+        'https://example.com/logo.png',
+        'data:text/plain;blah',
+        Symbol('bar'),
+      ].forEach((invalidIcon) => {
+        const provider: any = { name: 'test' };
+        const providerDetail = { info: getProviderInfo(), provider };
+        providerDetail.info.icon = invalidIcon as any;
 
-          expect(() => announceProvider(providerDetail)).toThrow(
-            providerInfoValidationError(),
-          );
-        });
+        expect(() => announceProvider(providerDetail)).toThrow(
+          providerInfoValidationError(),
+        );
       });
     });
 
-    it('should announce a provider', () => {
-      const provider: any = { name: 'test' };
-      const providerDetail = { info: getProviderInfo(), provider };
-      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
-      const addEventListener = jest.spyOn(window, 'addEventListener');
+    it('throws if the `name` field is invalid', () => {
+      [null, undefined, '', {}, [], Symbol('bar')].forEach((invalidName) => {
+        const provider: any = { name: 'test' };
+        const providerDetail = { info: getProviderInfo(), provider };
+        providerDetail.info.name = invalidName as any;
 
-      announceProvider(providerDetail);
+        expect(() => announceProvider(providerDetail)).toThrow(
+          providerInfoValidationError(),
+        );
+      });
+    });
 
-      expect(dispatchEvent).toHaveBeenCalledTimes(1);
-      expect(dispatchEvent).toHaveBeenCalledWith(
-        new CustomEvent('eip6963:announceProvider', {
-          detail: {
-            info: getProviderInfo(),
-            provider,
-          },
-        }),
-      );
-      expect(addEventListener).toHaveBeenCalledTimes(1);
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:requestProvider',
-        expect.any(Function),
-      );
+    it('throws if the `uuid` field is invalid', () => {
+      [null, undefined, '', 'foo', Symbol('bar')].forEach((invalidUuid) => {
+        const provider: any = { name: 'test' };
+        const providerDetail = { info: getProviderInfo(), provider };
+        providerDetail.info.uuid = invalidUuid as any;
+
+        expect(() => announceProvider(providerDetail)).toThrow(
+          providerInfoValidationError(),
+        );
+      });
+    });
+
+    it('throws if the `rdns` field is invalid', () => {
+      [
+        null,
+        undefined,
+        '',
+        'not-a-valid-domain',
+        '..com',
+        'com.',
+        Symbol('bar'),
+      ].forEach((invalidRdns) => {
+        const provider: any = { name: 'test' };
+        const providerDetail = { info: getProviderInfo(), provider };
+        providerDetail.info.rdns = invalidRdns as any;
+
+        expect(() => announceProvider(providerDetail)).toThrow(
+          providerInfoValidationError(),
+        );
+      });
     });
   });
 
-  describe('requestProvider', () => {
-    it('should receive an announced provider (called before announceProvider)', async () => {
-      const provider: any = { name: 'test' };
-      const providerDetail = { info: getProviderInfo(), provider };
-      const handleProvider = jest.fn();
-      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
-      const addEventListener = jest.spyOn(window, 'addEventListener');
+  it('provider is initialized before dapp', async () => {
+    const provider: any = { name: 'test' };
+    const providerDetail = { info: getProviderInfo(), provider };
+    const handleProvider = jest.fn();
+    const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+    const addEventListener = jest.spyOn(window, 'addEventListener');
 
-      requestProvider(handleProvider);
-      announceProvider(providerDetail);
-      await delay();
+    announceProvider(providerDetail);
+    requestProvider(handleProvider);
+    await delay();
 
-      expect(dispatchEvent).toHaveBeenCalledTimes(2);
-      expect(dispatchEvent).toHaveBeenNthCalledWith(
-        1,
-        new Event('eip6963:requestProvider'),
-      );
-      expect(dispatchEvent).toHaveBeenNthCalledWith(
-        2,
-        new CustomEvent('eip6963:announceProvider'),
-      );
+    expect(dispatchEvent).toHaveBeenCalledTimes(3);
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      1,
+      new CustomEvent('eip6963:announceProvider'),
+    );
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      2,
+      new Event('eip6963:requestProvider'),
+    );
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      3,
+      new CustomEvent('eip6963:announceProvider'),
+    );
 
-      expect(addEventListener).toHaveBeenCalledTimes(2);
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:announceProvider',
-        expect.any(Function),
-      );
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:requestProvider',
-        expect.any(Function),
-      );
+    expect(addEventListener).toHaveBeenCalledTimes(2);
+    expect(addEventListener).toHaveBeenCalledWith(
+      'eip6963:announceProvider',
+      expect.any(Function),
+    );
+    expect(addEventListener).toHaveBeenCalledWith(
+      'eip6963:requestProvider',
+      expect.any(Function),
+    );
 
-      expect(handleProvider).toHaveBeenCalledTimes(1);
-      expect(handleProvider).toHaveBeenCalledWith({
-        info: getProviderInfo(),
-        provider,
-      });
+    expect(handleProvider).toHaveBeenCalledTimes(1);
+    expect(handleProvider).toHaveBeenCalledWith({
+      info: getProviderInfo(),
+      provider,
     });
+  });
 
-    it('should receive an announced provider (called after announceProvider)', async () => {
-      const provider: any = { name: 'test' };
-      const providerDetail = { info: getProviderInfo(), provider };
-      const handleProvider = jest.fn();
-      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
-      const addEventListener = jest.spyOn(window, 'addEventListener');
+  it('dapp is initialized before provider', async () => {
+    const provider: any = { name: 'test' };
+    const providerDetail = { info: getProviderInfo(), provider };
+    const handleProvider = jest.fn();
+    const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+    const addEventListener = jest.spyOn(window, 'addEventListener');
 
-      announceProvider(providerDetail);
-      requestProvider(handleProvider);
-      await delay();
+    requestProvider(handleProvider);
+    announceProvider(providerDetail);
+    await delay();
 
-      // Notice that 3 events are dispatched in total when requestProvider is
-      // called after announceProvider.
-      expect(dispatchEvent).toHaveBeenCalledTimes(3);
-      expect(dispatchEvent).toHaveBeenNthCalledWith(
-        1,
-        new CustomEvent('eip6963:announceProvider'),
-      );
-      expect(dispatchEvent).toHaveBeenNthCalledWith(
-        2,
-        new Event('eip6963:requestProvider'),
-      );
-      expect(dispatchEvent).toHaveBeenNthCalledWith(
-        3,
-        new CustomEvent('eip6963:announceProvider'),
-      );
+    expect(dispatchEvent).toHaveBeenCalledTimes(2);
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      1,
+      new Event('eip6963:requestProvider'),
+    );
+    expect(dispatchEvent).toHaveBeenNthCalledWith(
+      2,
+      new CustomEvent('eip6963:announceProvider'),
+    );
 
-      expect(addEventListener).toHaveBeenCalledTimes(2);
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:announceProvider',
-        expect.any(Function),
-      );
-      expect(addEventListener).toHaveBeenCalledWith(
-        'eip6963:requestProvider',
-        expect.any(Function),
-      );
+    expect(addEventListener).toHaveBeenCalledTimes(2);
+    expect(addEventListener).toHaveBeenCalledWith(
+      'eip6963:announceProvider',
+      expect.any(Function),
+    );
+    expect(addEventListener).toHaveBeenCalledWith(
+      'eip6963:requestProvider',
+      expect.any(Function),
+    );
 
-      expect(handleProvider).toHaveBeenCalledTimes(1);
-      expect(handleProvider).toHaveBeenCalledWith({
-        info: getProviderInfo(),
-        provider,
-      });
+    expect(handleProvider).toHaveBeenCalledTimes(1);
+    expect(handleProvider).toHaveBeenCalledWith({
+      info: getProviderInfo(),
+      provider,
     });
   });
 });

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -1,0 +1,162 @@
+/* eslint-disable no-restricted-globals */
+
+import {
+  announceProvider,
+  requestProvider,
+  MetaMaskEIP6963ProviderInfo,
+} from './EIP6963';
+
+describe('EIP6963', () => {
+  describe('MetaMaskEIP6963ProviderInfo', () => {
+    it('has expected shape and values', () => {
+      expect(MetaMaskEIP6963ProviderInfo).toStrictEqual({
+        walletId: 'io.metamask',
+        uuid: expect.any(String),
+        name: 'MetaMask',
+        icon: 'https://raw.githubusercontent.com/MetaMask/brand-resources/cb6fd847f3a9cc5e231c749383c3898935e62eab/SVG/metamask-fox.svg',
+      });
+    });
+  });
+
+  describe('announceProvider', () => {
+    it('should announce a provider', () => {
+      const provider = { name: 'test' };
+      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+
+      announceProvider(provider as any);
+
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new CustomEvent('eip6963:announceProvider', {
+          detail: {
+            info: MetaMaskEIP6963ProviderInfo,
+            provider,
+          },
+        }),
+      );
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:requestProvider',
+        expect.any(Function),
+      );
+    });
+
+    it('should not be affected by modifying MetaMaskEIP6963ProviderInfo', () => {
+      const provider = { name: 'test' };
+      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+
+      const { walletId } = MetaMaskEIP6963ProviderInfo;
+      (MetaMaskEIP6963ProviderInfo as any).walletId = 'foo';
+      announceProvider(provider as any);
+
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new CustomEvent('eip6963:announceProvider', {
+          detail: {
+            info: { ...MetaMaskEIP6963ProviderInfo, walletId },
+            provider,
+          },
+        }),
+      );
+      expect((dispatchEvent as any).mock.calls[0][0].detail).toStrictEqual({
+        info: { ...MetaMaskEIP6963ProviderInfo, walletId },
+        provider,
+      });
+
+      expect(addEventListener).toHaveBeenCalledTimes(1);
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:requestProvider',
+        expect.any(Function),
+      );
+
+      // Reset
+      (MetaMaskEIP6963ProviderInfo as any).walletId = walletId;
+    });
+  });
+
+  describe('requestProvider', () => {
+    it('should receive an announced provider (called before announceProvider)', async () => {
+      const provider: any = { name: 'test' };
+      const handleProvider = jest.fn();
+      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+
+      requestProvider(handleProvider);
+      announceProvider(provider);
+      await delay();
+
+      expect(dispatchEvent).toHaveBeenCalledTimes(2);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new Event('eip6963:requestProvider'),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new CustomEvent('eip6963:announceProvider'),
+      );
+
+      expect(addEventListener).toHaveBeenCalledTimes(2);
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:announceProvider',
+        expect.any(Function),
+      );
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:requestProvider',
+        expect.any(Function),
+      );
+
+      expect(handleProvider).toHaveBeenCalledTimes(1);
+      expect(handleProvider).toHaveBeenCalledWith({
+        info: MetaMaskEIP6963ProviderInfo,
+        provider,
+      });
+    });
+
+    it('should receive an announced provider (called after announceProvider)', async () => {
+      const provider: any = { name: 'test' };
+      const handleProvider = jest.fn();
+      const dispatchEvent = jest.spyOn(window, 'dispatchEvent');
+      const addEventListener = jest.spyOn(window, 'addEventListener');
+
+      announceProvider(provider);
+      requestProvider(handleProvider);
+      await delay();
+
+      // Notice that 3 events are dispatched in total when requestProvider is
+      // called after announceProvider.
+      expect(dispatchEvent).toHaveBeenCalledTimes(3);
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new Event('eip6963:requestProvider'),
+      );
+      expect(dispatchEvent).toHaveBeenCalledWith(
+        new CustomEvent('eip6963:announceProvider'),
+      );
+
+      expect(addEventListener).toHaveBeenCalledTimes(2);
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:announceProvider',
+        expect.any(Function),
+      );
+      expect(addEventListener).toHaveBeenCalledWith(
+        'eip6963:requestProvider',
+        expect.any(Function),
+      );
+
+      expect(handleProvider).toHaveBeenCalledTimes(1);
+      expect(handleProvider).toHaveBeenCalledWith({
+        info: MetaMaskEIP6963ProviderInfo,
+        provider,
+      });
+    });
+  });
+});
+
+/**
+ * Delay for a number of milliseconds by awaiting a promise
+ * resolved after the specified number of milliseconds.
+ *
+ * @param ms - The number of milliseconds to delay for.
+ */
+async function delay(ms = 1) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -8,7 +8,7 @@ const getProviderInfo = () => ({
 
 const providerInfoValidationError = () =>
   new Error(
-    'Invalid EIP-6963 provider detail. See https://eips.ethereum.org/EIPS/eip-6963 for requirements.',
+    'Invalid EIP-6963 ProviderDetail object. See https://eips.ethereum.org/EIPS/eip-6963 for requirements.',
   );
 
 describe('EIP6963', () => {
@@ -53,6 +53,19 @@ describe('EIP6963', () => {
           const provider: any = { name: 'test' };
           const providerDetail = { info: getProviderInfo(), provider };
           providerDetail.info.uuid = invalidUuid as any;
+
+          expect(() => announceProvider(providerDetail)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
+      });
+    });
+
+    describe('provider validation', () => {
+      it('throws if the provider is not a plain object', () => {
+        [null, undefined, Symbol('bar'), []].forEach((invalidProvider) => {
+          const provider: any = invalidProvider;
+          const providerDetail = { info: getProviderInfo(), provider };
 
           expect(() => announceProvider(providerDetail)).toThrow(
             providerInfoValidationError(),

--- a/src/EIP6963.test.ts
+++ b/src/EIP6963.test.ts
@@ -24,17 +24,23 @@ describe('EIP-6963', () => {
       });
 
       it('throws if the `icon` field is invalid', () => {
-        [null, undefined, '', 'not-a-url', Symbol('bar')].forEach(
-          (invalidIcon) => {
-            const provider: any = { name: 'test' };
-            const providerDetail = { info: getProviderInfo(), provider };
-            providerDetail.info.icon = invalidIcon as any;
+        [
+          null,
+          undefined,
+          '',
+          'not-a-data-uri',
+          'https://example.com/logo.png',
+          'data:text/plain;blah',
+          Symbol('bar'),
+        ].forEach((invalidIcon) => {
+          const provider: any = { name: 'test' };
+          const providerDetail = { info: getProviderInfo(), provider };
+          providerDetail.info.icon = invalidIcon as any;
 
-            expect(() => announceProvider(providerDetail)).toThrow(
-              providerInfoValidationError(),
-            );
-          },
-        );
+          expect(() => announceProvider(providerDetail)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
       });
 
       it('throws if the `name` field is invalid', () => {
@@ -54,6 +60,26 @@ describe('EIP-6963', () => {
           const provider: any = { name: 'test' };
           const providerDetail = { info: getProviderInfo(), provider };
           providerDetail.info.uuid = invalidUuid as any;
+
+          expect(() => announceProvider(providerDetail)).toThrow(
+            providerInfoValidationError(),
+          );
+        });
+      });
+
+      it('throws if the `rdns` field is invalid', () => {
+        [
+          null,
+          undefined,
+          '',
+          'not-a-valid-domain',
+          '..com',
+          'com.',
+          Symbol('bar'),
+        ].forEach((invalidRdns) => {
+          const provider: any = { name: 'test' };
+          const providerDetail = { info: getProviderInfo(), provider };
+          providerDetail.info.rdns = invalidRdns as any;
 
           expect(() => announceProvider(providerDetail)).toThrow(
             providerInfoValidationError(),

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -47,7 +47,7 @@ export type EIP6963ProviderDetail = {
 };
 
 /**
- * Event for requesting an EVM provider
+ * Event for requesting an EVM provider.
  *
  * @type EIP6963RequestProviderEvent
  * @property type - The name of the event.
@@ -57,7 +57,7 @@ export type EIP6963RequestProviderEvent = Event & {
 };
 
 /**
- * Event for announcing an EVM provider
+ * Event for announcing an EVM provider.
  *
  * @type EIP6963RequestProviderEvent
  * @property type - The name of the event.
@@ -77,9 +77,9 @@ const FQDN_REGEX =
   /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/u;
 
 /**
- * Forwards every announced provider to the provided handler by listening for
- * {@link EIP6963AnnounceProviderEvent}, and dispatches an
- * {@link EIP6963RequestProviderEvent}.
+ * Intended to be used by a dapp. Forwards every announced provider to the
+ * provided handler by listening for * {@link EIP6963AnnounceProviderEvent},
+ * and dispatches an {@link EIP6963RequestProviderEvent}.
  *
  * @param handleProvider - A function that handles an announced provider.
  */
@@ -102,8 +102,9 @@ export function requestProvider<HandlerReturnType>(
 }
 
 /**
- * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and
- * listening for {@link EIP6963RequestProviderEvent} to re-announce.
+ * Intended to be used by a wallet. Announces a provider by dispatching
+ * an {@link EIP6963AnnounceProviderEvent}, and listening for
+ * {@link EIP6963RequestProviderEvent} to re-announce.
  *
  * @throws If the {@link EIP6963ProviderDetail} is invalid.
  * @param providerDetail - The {@link EIP6963ProviderDetail} to announce.

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -73,13 +73,16 @@ export function requestProvider<HandlerReturnType>(
   window.dispatchEvent(new Event(EIP6963EventNames.Request));
 }
 
+// https://caniuse.com/js-regexp-lookbehind
+// MetaMask Mobile, which uses Safari for the in-app browser, does NOT support lookbehind regexes.
+
 // https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
 const UUID_V4_REGEX =
   /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u;
 
 // https://stackoverflow.com/a/20204811
 const FQDN_REGEX =
-  /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/u;
+  /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/u;
 
 /**
  * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -73,11 +73,13 @@ export function requestProvider<HandlerReturnType>(
   window.dispatchEvent(new Event(EIP6963EventNames.Request));
 }
 
-/**
- * Courtesy https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
- */
+// https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
 const UUID_V4_REGEX =
   /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u;
+
+// https://stackoverflow.com/a/20204811
+const FQDN_REGEX =
+  /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/u;
 
 /**
  * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and
@@ -175,20 +177,10 @@ function isValidProviderDetail(
     typeof info.name === 'string' &&
     Boolean(info.name) &&
     typeof info.icon === 'string' &&
-    isImageDataUriLike(info.icon) &&
+    info.icon.startsWith('data:image') &&
     typeof info.rdns === 'string' &&
-    Boolean(info.rdns)
+    FQDN_REGEX.test(info.rdns)
   );
-}
-
-/**
- * Checks if a string is a data URI like.
- *
- * @param uri - The string to check.
- * @returns Whether the string looks like a data URI specifying an image.
- */
-function isImageDataUriLike(uri: string) {
-  return uri.startsWith('data:image');
 }
 
 /**

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -7,6 +7,14 @@ enum EIP6963EventNames {
   Request = 'eip6963:requestProvider', // eslint-disable-line @typescript-eslint/no-shadow
 }
 
+declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface WindowEventMap {
+    [EIP6963EventNames.Request]: EIP6963RequestProviderEvent;
+    [EIP6963EventNames.Announce]: EIP6963AnnounceProviderEvent;
+  }
+}
+
 /**
  * Represents the assets needed to display and identify a wallet.
  */
@@ -59,7 +67,7 @@ export function requestProvider<HandlerReturnType>(
   handleProvider: (providerDetail: EIP6963ProviderDetail) => HandlerReturnType,
 ): void {
   window.addEventListener(
-    EIP6963EventNames.Announce as any,
+    EIP6963EventNames.Announce,
     (event: EIP6963AnnounceProviderEvent) => {
       if (!isValidAnnounceProviderEvent(event)) {
         throwErrorEIP6963(
@@ -72,9 +80,6 @@ export function requestProvider<HandlerReturnType>(
 
   window.dispatchEvent(new Event(EIP6963EventNames.Request));
 }
-
-// https://caniuse.com/js-regexp-lookbehind
-// MetaMask Mobile, which uses Safari for the in-app browser, does NOT support lookbehind regexes.
 
 // https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
 const UUID_V4_REGEX =
@@ -108,7 +113,7 @@ export function announceProvider(providerDetail: EIP6963ProviderDetail): void {
 
   _announceProvider();
   window.addEventListener(
-    EIP6963EventNames.Request as any,
+    EIP6963EventNames.Request,
     (event: EIP6963RequestProviderEvent) => {
       if (!isValidRequestProviderEvent(event)) {
         throwErrorEIP6963(
@@ -129,12 +134,7 @@ export function announceProvider(providerDetail: EIP6963ProviderDetail): void {
 function isValidRequestProviderEvent(
   event: unknown,
 ): event is EIP6963RequestProviderEvent {
-  const providerEvent = event as EIP6963RequestProviderEvent;
-
-  return (
-    providerEvent instanceof Event &&
-    providerEvent.type === EIP6963EventNames.Request
-  );
+  return event instanceof Event && event.type === EIP6963EventNames.Request;
 }
 
 /**
@@ -146,13 +146,11 @@ function isValidRequestProviderEvent(
 function isValidAnnounceProviderEvent(
   event: unknown,
 ): event is EIP6963AnnounceProviderEvent {
-  const providerEvent = event as EIP6963AnnounceProviderEvent;
-
   return (
-    providerEvent instanceof CustomEvent &&
-    providerEvent.type === EIP6963EventNames.Announce &&
-    Object.isFrozen(providerEvent.detail) &&
-    isValidProviderDetail(providerEvent.detail)
+    event instanceof CustomEvent &&
+    event.type === EIP6963EventNames.Announce &&
+    Object.isFrozen(event.detail) &&
+    isValidProviderDetail(event.detail)
   );
 }
 
@@ -172,7 +170,7 @@ function isValidProviderDetail(
   ) {
     return false;
   }
-  const { info } = providerDetail as EIP6963ProviderDetail;
+  const { info } = providerDetail;
 
   return (
     typeof info.uuid === 'string' &&

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -1,5 +1,4 @@
 import { isObject } from '@metamask/utils';
-import { v4 as uuid } from 'uuid';
 
 import { BaseProvider } from './BaseProvider';
 
@@ -16,20 +15,6 @@ export type EIP6963ProviderInfo = {
   uuid: string;
   name: string;
   icon: string;
-};
-
-type MetaMaskEIP6963ProviderInfo = EIP6963ProviderInfo & {
-  walletId: 'io.metamask';
-  uuid: string;
-  name: 'MetaMask';
-  icon: `https://${string}.svg`;
-};
-
-export const MetaMaskEIP6963ProviderInfo: MetaMaskEIP6963ProviderInfo = {
-  walletId: 'io.metamask',
-  uuid: uuid(),
-  name: 'MetaMask',
-  icon: 'https://raw.githubusercontent.com/MetaMask/brand-resources/cb6fd847f3a9cc5e231c749383c3898935e62eab/SVG/metamask-fox.svg',
 };
 
 export type EIP6963ProviderDetail = {
@@ -73,19 +58,22 @@ export function requestProvider<HandlerReturnType>(
   window.dispatchEvent(new Event(EIP6963EventNames.Request));
 }
 
-const _MetaMaskEIP6963ProviderInfo = { ...MetaMaskEIP6963ProviderInfo };
-
 /**
  * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and
  * listening for {@link EIP6963RequestProviderEvent} to re-announce.
  *
- * @param provider - The provider to announce.
+ * @param providerDetail - The {@link EIP6963ProviderDetail} to announce.
+ * @param providerDetail.info - The {@link EIP6963ProviderInfo} to announce.
+ * @param providerDetail.provider - The provider to announce.
  */
-export function announceProvider(provider: BaseProvider): void {
+export function announceProvider({
+  info,
+  provider,
+}: EIP6963ProviderDetail): void {
   const _announceProvider = () =>
     window.dispatchEvent(
       new CustomEvent(EIP6963EventNames.Announce, {
-        detail: { info: _MetaMaskEIP6963ProviderInfo, provider },
+        detail: { info: { ...info }, provider },
       }),
     );
 

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -20,9 +20,13 @@ export type EIP6963ProviderInfo = {
    */
   name: string;
   /**
-   * The URL of an icon for the wallet.
+   * The icon for the wallet. MUST be data URI.
    */
   icon: string;
+  /**
+   * The reverse syntax domain name identifier for the wallet.
+   */
+  rdns: string;
 };
 
 /**
@@ -166,29 +170,25 @@ function isValidProviderDetail(
   const { info } = providerDetail as EIP6963ProviderDetail;
 
   return (
-    typeof info.icon === 'string' &&
-    isValidUrl(info.icon) &&
+    typeof info.uuid === 'string' &&
+    UUID_V4_REGEX.test(info.uuid) &&
     typeof info.name === 'string' &&
     Boolean(info.name) &&
-    typeof info.uuid === 'string' &&
-    UUID_V4_REGEX.test(info.uuid)
+    typeof info.icon === 'string' &&
+    isImageDataUriLike(info.icon) &&
+    typeof info.rdns === 'string' &&
+    Boolean(info.rdns)
   );
 }
 
 /**
- * Checks if a string is a valid URL.
+ * Checks if a string is a data URI like.
  *
- * @param url - The string to check.
- * @returns Whether the string is a valid URL.
+ * @param uri - The string to check.
+ * @returns Whether the string looks like a data URI specifying an image.
  */
-function isValidUrl(url: string) {
-  try {
-    // eslint-disable-next-line no-new
-    new URL(url);
-    return true;
-  } catch (error) {
-    return false;
-  }
+function isImageDataUriLike(uri: string) {
+  return uri.startsWith('data:image');
 }
 
 /**

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -58,7 +58,9 @@ export function requestProvider<HandlerReturnType>(
     EIP6963EventNames.Announce as any,
     (event: EIP6963AnnounceProviderEvent) => {
       if (!isValidAnnounceProviderEvent(event)) {
-        throwErrorEIP6963(`Invalid EIP-6963 AnnounceProviderEvent object received from ${EIP6963EventNames.Announce} event.`);
+        throwErrorEIP6963(
+          `Invalid EIP-6963 AnnounceProviderEvent object received from ${EIP6963EventNames.Announce} event.`,
+        );
       }
       handleProvider(event.detail);
     },
@@ -100,7 +102,9 @@ export function announceProvider(providerDetail: EIP6963ProviderDetail): void {
     EIP6963EventNames.Request as any,
     (event: EIP6963RequestProviderEvent) => {
       if (!isValidRequestProviderEvent(event)) {
-        throwErrorEIP6963(`Invalid EIP-6963 RequestProviderEvent object received from ${EIP6963EventNames.Request} event.`);
+        throwErrorEIP6963(
+          `Invalid EIP-6963 RequestProviderEvent object received from ${EIP6963EventNames.Request} event.`,
+        );
       }
       _announceProvider();
     },

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -2,6 +2,9 @@ import { isObject } from '@metamask/utils';
 
 import { BaseProvider } from './BaseProvider';
 
+/**
+ * Describes the possible EIP-6963 event names
+ */
 enum EIP6963EventNames {
   Announce = 'eip6963:announceProvider',
   Request = 'eip6963:requestProvider', // eslint-disable-line @typescript-eslint/no-shadow
@@ -17,44 +20,61 @@ declare global {
 
 /**
  * Represents the assets needed to display and identify a wallet.
+ *
+ * @type EIP6963ProviderInfo
+ * @property uuid - A locally unique identifier for the wallet. MUST be a v4 UUID.
+ * @property name - The name of the wallet.
+ * @property icon - The icon for the wallet. MUST be data URI.
+ * @property rdns - The reverse syntax domain name identifier for the wallet.
  */
 export type EIP6963ProviderInfo = {
-  /**
-   * A locally unique identifier for the wallet. MUST be a v4 UUID.
-   */
   uuid: string;
-  /**
-   * The name of the wallet.
-   */
   name: string;
-  /**
-   * The icon for the wallet. MUST be data URI.
-   */
   icon: string;
-  /**
-   * The reverse syntax domain name identifier for the wallet.
-   */
   rdns: string;
 };
 
 /**
  * Represents a provider and the information relevant for the dapp.
+ *
+ * @type EIP6963ProviderDetail
+ * @property info - The EIP6963ProviderInfo object.
+ * @property provider - The provider instance.
  */
 export type EIP6963ProviderDetail = {
   info: EIP6963ProviderInfo;
   provider: BaseProvider;
 };
 
-// Requesting an EVM provider
+/**
+ * Event for requesting an EVM provider
+ *
+ * @type EIP6963RequestProviderEvent
+ * @property type - The name of the event.
+ */
 export type EIP6963RequestProviderEvent = Event & {
   type: EIP6963EventNames.Request;
 };
 
-// Annoucing an EVM provider
+/**
+ * Event for announcing an EVM provider
+ *
+ * @type EIP6963RequestProviderEvent
+ * @property type - The name of the event.
+ * @property detail - The detail object of the event.
+ */
 export type EIP6963AnnounceProviderEvent = CustomEvent & {
   type: EIP6963EventNames.Announce;
   detail: EIP6963ProviderDetail;
 };
+
+// https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
+const UUID_V4_REGEX =
+  /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u;
+
+// https://stackoverflow.com/a/20204811
+const FQDN_REGEX =
+  /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/u;
 
 /**
  * Forwards every announced provider to the provided handler by listening for
@@ -80,14 +100,6 @@ export function requestProvider<HandlerReturnType>(
 
   window.dispatchEvent(new Event(EIP6963EventNames.Request));
 }
-
-// https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
-const UUID_V4_REGEX =
-  /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u;
-
-// https://stackoverflow.com/a/20204811
-const FQDN_REGEX =
-  /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/u;
 
 /**
  * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -12,11 +12,6 @@ enum EIP6963EventNames {
  */
 export type EIP6963ProviderInfo = {
   /**
-   * The global identifier for the wallet. SHOULD be in reverse domain format,
-   * e.g. `com.wallet.example`.
-   */
-  walletId: string;
-  /**
    * A locally unique identifier for the wallet. MUST be a v4 UUID.
    */
   uuid: string;
@@ -133,9 +128,7 @@ function isValidProviderDetail(
     typeof info.name === 'string' &&
     Boolean(info.name) &&
     typeof info.uuid === 'string' &&
-    UUID_V4_REGEX.test(info.uuid) &&
-    typeof info.walletId === 'string' &&
-    Boolean(info.walletId)
+    UUID_V4_REGEX.test(info.uuid)
   );
 }
 

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -1,0 +1,99 @@
+import { isObject } from '@metamask/utils';
+import { v4 as uuid } from 'uuid';
+
+import { BaseProvider } from './BaseProvider';
+
+enum EIP6963EventNames {
+  Announce = 'eip6963:announceProvider',
+  Request = 'eip6963:requestProvider', // eslint-disable-line @typescript-eslint/no-shadow
+}
+
+/**
+ * Represents the assets needed to display a wallet
+ */
+export type EIP6963ProviderInfo = {
+  walletId: string;
+  uuid: string;
+  name: string;
+  icon: string;
+};
+
+type MetaMaskEIP6963ProviderInfo = EIP6963ProviderInfo & {
+  walletId: 'io.metamask';
+  uuid: string;
+  name: 'MetaMask';
+  icon: `https://${string}.svg`;
+};
+
+export const MetaMaskEIP6963ProviderInfo: MetaMaskEIP6963ProviderInfo = {
+  walletId: 'io.metamask',
+  uuid: uuid(),
+  name: 'MetaMask',
+  icon: 'https://raw.githubusercontent.com/MetaMask/brand-resources/cb6fd847f3a9cc5e231c749383c3898935e62eab/SVG/metamask-fox.svg',
+};
+
+export type EIP6963ProviderDetail = {
+  info: EIP6963ProviderInfo;
+  provider: BaseProvider;
+};
+
+// Requesting an EVM provider
+export type EIP6963RequestProviderEvent = Event & {
+  type: EIP6963EventNames.Request;
+};
+
+// Annoucing an EVM provider
+export type EIP6963AnnounceProviderEvent = CustomEvent & {
+  type: EIP6963EventNames.Announce;
+  detail: EIP6963ProviderDetail;
+};
+
+/**
+ * Forwards every announced provider to the provided handler by listening for
+ * {@link EIP6963AnnounceProviderEvent}, and dispatches an
+ * {@link EIP6963RequestProviderEvent}.
+ *
+ * @param handleProvider - A function that handles an announced provider.
+ */
+export function requestProvider<HandlerReturnType>(
+  handleProvider: (providerDetail: EIP6963ProviderDetail) => HandlerReturnType,
+): void {
+  window.addEventListener(
+    EIP6963EventNames.Announce as any,
+    (event: EIP6963AnnounceProviderEvent) => {
+      if (
+        event.type === EIP6963EventNames.Announce &&
+        isObject(event.detail?.provider)
+      ) {
+        handleProvider(event.detail);
+      }
+    },
+  );
+
+  window.dispatchEvent(new Event(EIP6963EventNames.Request));
+}
+
+const _MetaMaskEIP6963ProviderInfo = { ...MetaMaskEIP6963ProviderInfo };
+
+/**
+ * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and
+ * listening for {@link EIP6963RequestProviderEvent} to re-announce.
+ *
+ * @param provider - The provider to announce.
+ */
+export function announceProvider(provider: BaseProvider): void {
+  const _announceProvider = () =>
+    window.dispatchEvent(
+      new CustomEvent(EIP6963EventNames.Announce, {
+        detail: { info: _MetaMaskEIP6963ProviderInfo, provider },
+      }),
+    );
+
+  _announceProvider();
+  window.addEventListener(
+    EIP6963EventNames.Request as any,
+    (_event: EIP6963RequestProviderEvent) => {
+      _announceProvider();
+    },
+  );
+}

--- a/src/EIP6963.ts
+++ b/src/EIP6963.ts
@@ -8,15 +8,31 @@ enum EIP6963EventNames {
 }
 
 /**
- * Represents the assets needed to display a wallet
+ * Represents the assets needed to display and identify a wallet.
  */
 export type EIP6963ProviderInfo = {
+  /**
+   * The global identifier for the wallet. SHOULD be in reverse domain format,
+   * e.g. `com.wallet.example`.
+   */
   walletId: string;
+  /**
+   * A locally unique identifier for the wallet. MUST be a v4 UUID.
+   */
   uuid: string;
+  /**
+   * The name of the wallet.
+   */
   name: string;
+  /**
+   * The URL of an icon for the wallet.
+   */
   icon: string;
 };
 
+/**
+ * Represents a provider and the information relevant for the dapp.
+ */
 export type EIP6963ProviderDetail = {
   info: EIP6963ProviderInfo;
   provider: BaseProvider;
@@ -59,6 +75,12 @@ export function requestProvider<HandlerReturnType>(
 }
 
 /**
+ * Courtesy https://github.com/thenativeweb/uuidv4/blob/bdcf3a3138bef4fb7c51f389a170666f9012c478/lib/uuidv4.ts#L5
+ */
+const UUID_V4_REGEX =
+  /(?:^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}$)|(?:^0{8}-0{4}-0{4}-0{4}-0{12}$)/u;
+
+/**
  * Announces a provider by dispatching an {@link EIP6963AnnounceProviderEvent}, and
  * listening for {@link EIP6963RequestProviderEvent} to re-announce.
  *
@@ -70,6 +92,10 @@ export function announceProvider({
   info,
   provider,
 }: EIP6963ProviderDetail): void {
+  if (typeof info.uuid !== 'string' || !UUID_V4_REGEX.test(info.uuid)) {
+    throw new Error('Invalid `uuid` field. Must be a v4 UUID.');
+  }
+
   const _announceProvider = () =>
     window.dispatchEvent(
       new CustomEvent(EIP6963EventNames.Announce, {

--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -84,7 +84,7 @@ async function getInitializedProvider({
     }
     onWrite(name, data);
   });
-  // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+  // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
   (global.chrome.runtime.connect as any).mockImplementation(() => {
     return port;
   });
@@ -99,7 +99,7 @@ async function getInitializedProvider({
 
 describe('createExternalExtensionProvider', () => {
   it('can be called and not throw', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });
@@ -107,7 +107,7 @@ describe('createExternalExtensionProvider', () => {
   });
 
   it('calls connect', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });
@@ -116,7 +116,7 @@ describe('createExternalExtensionProvider', () => {
   });
 
   it('returns a stream provider', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });
@@ -125,7 +125,7 @@ describe('createExternalExtensionProvider', () => {
   });
 
   it('supports Flask', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });
@@ -137,7 +137,7 @@ describe('createExternalExtensionProvider', () => {
   });
 
   it('supports Beta', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });
@@ -149,7 +149,7 @@ describe('createExternalExtensionProvider', () => {
   });
 
   it('supports custom extension ID', () => {
-    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.js`
+    // `global.chrome.runtime` mock setup by `jest-chrome` in `jest.setup.browser.js`
     (global.chrome.runtime.connect as any).mockImplementation(() => {
       return new MockPort();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,13 @@
 import { BaseProvider } from './BaseProvider';
+import {
+  announceProvider as eip6963AnnounceProvider,
+  requestProvider as eip6963RequestProvider,
+  MetaMaskEIP6963ProviderInfo,
+  EIP6963AnnounceProviderEvent,
+  EIP6963ProviderDetail,
+  EIP6963ProviderInfo,
+  EIP6963RequestProviderEvent,
+} from './EIP6963';
 import { createExternalExtensionProvider } from './extension-provider/createExternalExtensionProvider';
 import {
   initializeProvider,
@@ -11,6 +20,13 @@ import {
 import { shimWeb3 } from './shimWeb3';
 import { StreamProvider } from './StreamProvider';
 
+export type {
+  EIP6963AnnounceProviderEvent,
+  EIP6963ProviderDetail,
+  EIP6963ProviderInfo,
+  EIP6963RequestProviderEvent,
+};
+
 export {
   BaseProvider,
   createExternalExtensionProvider,
@@ -20,4 +36,7 @@ export {
   setGlobalProvider,
   shimWeb3,
   StreamProvider,
+  eip6963AnnounceProvider,
+  eip6963RequestProvider,
+  MetaMaskEIP6963ProviderInfo,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { BaseProvider } from './BaseProvider';
 import {
   announceProvider as eip6963AnnounceProvider,
   requestProvider as eip6963RequestProvider,
-  MetaMaskEIP6963ProviderInfo,
   EIP6963AnnounceProviderEvent,
   EIP6963ProviderDetail,
   EIP6963ProviderInfo,
@@ -38,5 +37,4 @@ export {
   StreamProvider,
   eip6963AnnounceProvider,
   eip6963RequestProvider,
-  MetaMaskEIP6963ProviderInfo,
 };

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -14,9 +14,9 @@ type InitializeProviderOptions = {
   connectionStream: Duplex;
 
   /**
-   * The provider info that should be used for EIP6963 announcements.
+   * The EIP-6963 provider info that should be announced if set.
    */
-  providerInfo?: EIP6963ProviderInfo;
+  shouldAnnounceProviderInfo?: EIP6963ProviderInfo;
 
   /**
    * Whether the provider should be set as window.ethereum.
@@ -36,7 +36,7 @@ type InitializeProviderOptions = {
  * @param options.connectionStream - A Node.js stream.
  * @param options.jsonRpcStreamName - The name of the internal JSON-RPC stream.
  * @param options.maxEventListeners - The maximum number of event listeners.
- * @param options.providerInfo - The provider info that should be used for EIP6963.
+ * @param options.shouldAnnounceProviderInfo - The EIP-6963 provider info that should be announced if set.
  * @param options.shouldSendMetadata - Whether the provider should send page metadata.
  * @param options.shouldSetOnWindow - Whether the provider should be set as window.ethereum.
  * @param options.shouldShimWeb3 - Whether a window.web3 shim should be injected.
@@ -48,7 +48,7 @@ export function initializeProvider({
   jsonRpcStreamName,
   logger = console,
   maxEventListeners = 100,
-  providerInfo,
+  shouldAnnounceProviderInfo,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
   shouldShimWeb3 = false,
@@ -65,8 +65,11 @@ export function initializeProvider({
     deleteProperty: () => true,
   });
 
-  if (providerInfo) {
-    announceProvider({ info: providerInfo, provider: proxiedProvider });
+  if (shouldAnnounceProviderInfo) {
+    announceProvider({
+      info: shouldAnnounceProviderInfo,
+      provider: proxiedProvider,
+    });
   }
 
   if (shouldSetOnWindow) {

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -16,7 +16,7 @@ type InitializeProviderOptions = {
   /**
    * The EIP-6963 provider info that should be announced if set.
    */
-  shouldAnnounceProviderInfo?: EIP6963ProviderInfo;
+  providerInfo?: EIP6963ProviderInfo;
 
   /**
    * Whether the provider should be set as window.ethereum.
@@ -36,7 +36,7 @@ type InitializeProviderOptions = {
  * @param options.connectionStream - A Node.js stream.
  * @param options.jsonRpcStreamName - The name of the internal JSON-RPC stream.
  * @param options.maxEventListeners - The maximum number of event listeners.
- * @param options.shouldAnnounceProviderInfo - The EIP-6963 provider info that should be announced if set.
+ * @param options.providerInfo - The EIP-6963 provider info that should be announced if set.
  * @param options.shouldSendMetadata - Whether the provider should send page metadata.
  * @param options.shouldSetOnWindow - Whether the provider should be set as window.ethereum.
  * @param options.shouldShimWeb3 - Whether a window.web3 shim should be injected.
@@ -48,7 +48,7 @@ export function initializeProvider({
   jsonRpcStreamName,
   logger = console,
   maxEventListeners = 100,
-  shouldAnnounceProviderInfo,
+  providerInfo,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
   shouldShimWeb3 = false,
@@ -70,9 +70,9 @@ export function initializeProvider({
     },
   });
 
-  if (shouldAnnounceProviderInfo) {
+  if (providerInfo) {
     announceProvider({
-      info: shouldAnnounceProviderInfo,
+      info: providerInfo,
       provider: proxiedProvider,
     });
   }

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -1,5 +1,6 @@
 import { Duplex } from 'stream';
 
+import { EIP6963ProviderInfo, announceProvider } from './EIP6963';
 import {
   MetaMaskInpageProvider,
   MetaMaskInpageProviderOptions,
@@ -11,6 +12,11 @@ type InitializeProviderOptions = {
    * The stream used to connect to the wallet.
    */
   connectionStream: Duplex;
+
+  /**
+   * The provider info that should be used for EIP6963 announcements.
+   */
+  providerInfo?: EIP6963ProviderInfo;
 
   /**
    * Whether the provider should be set as window.ethereum.
@@ -30,6 +36,7 @@ type InitializeProviderOptions = {
  * @param options.connectionStream - A Node.js stream.
  * @param options.jsonRpcStreamName - The name of the internal JSON-RPC stream.
  * @param options.maxEventListeners - The maximum number of event listeners.
+ * @param options.providerInfo - The provider info that should be used for EIP6963.
  * @param options.shouldSendMetadata - Whether the provider should send page metadata.
  * @param options.shouldSetOnWindow - Whether the provider should be set as window.ethereum.
  * @param options.shouldShimWeb3 - Whether a window.web3 shim should be injected.
@@ -41,6 +48,7 @@ export function initializeProvider({
   jsonRpcStreamName,
   logger = console,
   maxEventListeners = 100,
+  providerInfo,
   shouldSendMetadata = true,
   shouldSetOnWindow = true,
   shouldShimWeb3 = false,
@@ -56,6 +64,10 @@ export function initializeProvider({
     // some common libraries, e.g. web3@1.x, mess with our API
     deleteProperty: () => true,
   });
+
+  if (providerInfo) {
+    announceProvider({ info: providerInfo, provider: proxiedProvider });
+  }
 
   if (shouldSetOnWindow) {
     setGlobalProvider(proxiedProvider);

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,6 +408,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@chainsafe/as-sha256@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@chainsafe/as-sha256@npm:0.4.1"
+  checksum: 6d86975e648ecdafd366802278ac15b392b252e967f3681412ec48b5a3518b936cc5e977517499882b084991446d25787d98f8f585891943688cc81549a44e9a
+  languageName: node
+  linkType: hard
+
+"@chainsafe/persistent-merkle-tree@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@chainsafe/persistent-merkle-tree@npm:0.6.1"
+  dependencies:
+    "@chainsafe/as-sha256": ^0.4.1
+    "@noble/hashes": ^1.3.0
+  checksum: 74614b8d40970dc930d5bf741619498b0bbbde5ff24ce45fce6ad122143aa77bf57249a28175b1b972cf56bff57d529a4258b7222ab4e60c1261119b5986c51b
+  languageName: node
+  linkType: hard
+
+"@chainsafe/ssz@npm:^0.11.1":
+  version: 0.11.1
+  resolution: "@chainsafe/ssz@npm:0.11.1"
+  dependencies:
+    "@chainsafe/as-sha256": ^0.4.1
+    "@chainsafe/persistent-merkle-tree": ^0.6.1
+  checksum: e3c2928f9ab4a0544e645f0302b9535046d1e6e1d4b3bd1c3dd6bc8e6302fddad6036d65e7900d1446f285f496051da05fa14c1bde590b511d03033907175c8f
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
@@ -467,6 +494,55 @@ __metadata:
   version: 8.39.0
   resolution: "@eslint/js@npm:8.39.0"
   checksum: 63fe36e2bfb5ff5705d1c1a8ccecd8eb2f81d9af239713489e767b0e398759c0177fcc75ad62581d02942f2776903a8496d5fae48dc2d883dff1b96fcb19e9e2
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/common@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "@ethereumjs/common@npm:3.1.2"
+  dependencies:
+    "@ethereumjs/util": ^8.0.6
+    crc-32: ^1.2.0
+  checksum: e80a8bc86476f1ce878bacb1915d91681671bb5303291cdcece26e456ac13a6158f0f59625cb02a1cfbdd7c9a7dc8b175f8d8f0fee596b3eb9dfb965465ad43d
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/rlp@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@ethereumjs/rlp@npm:4.0.1"
+  bin:
+    rlp: bin/rlp
+  checksum: 30db19c78faa2b6ff27275ab767646929207bb207f903f09eb3e4c273ce2738b45f3c82169ddacd67468b4f063d8d96035f2bf36f02b6b7e4d928eefe2e3ecbc
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/tx@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "@ethereumjs/tx@npm:4.1.2"
+  dependencies:
+    "@chainsafe/ssz": ^0.11.1
+    "@ethereumjs/common": ^3.1.2
+    "@ethereumjs/rlp": ^4.0.1
+    "@ethereumjs/util": ^8.0.6
+    ethereum-cryptography: ^2.0.0
+  peerDependencies:
+    c-kzg: ^1.0.8
+  peerDependenciesMeta:
+    c-kzg:
+      optional: true
+  checksum: ad2fb692c3746cd5935b01c98b6b54046ae2a1fccff57ad2209e10446f3b279a204d7477accf05b27078445b14379314077769662142ac07117c45a5a1ea427f
+  languageName: node
+  linkType: hard
+
+"@ethereumjs/util@npm:^8.0.6":
+  version: 8.0.6
+  resolution: "@ethereumjs/util@npm:8.0.6"
+  dependencies:
+    "@chainsafe/ssz": ^0.11.1
+    "@ethereumjs/rlp": ^4.0.1
+    ethereum-cryptography: ^2.0.0
+    micro-ftch: ^0.3.1
+  checksum: 034e06cddec27417318434a1a7cd7a9dc0f0b447c1f54423c515d8809c9697386eee6429d0a1c13517a85c696e6fdba570b243d882e65764c274859606027015
   languageName: node
   linkType: hard
 
@@ -1018,11 +1094,13 @@ __metadata:
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/object-multiplex": ^1.1.0
     "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^5.0.2
     "@types/chrome": ^0.0.233
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
     "@types/pump": ^1.1.0
     "@types/readable-stream": ^2.3.15
+    "@types/uuid": ^9.0.1
     "@types/webextension-polyfill": ^0.10.0
     "@typescript-eslint/eslint-plugin": ^5.43.0
     "@typescript-eslint/parser": ^5.43.0
@@ -1053,6 +1131,7 @@ __metadata:
     ts-node: ^10.7.0
     typedoc: ^0.23.15
     typescript: ~4.8.4
+    uuid: ^9.0.0
     webextension-polyfill: ^0.10.0
   languageName: unknown
   linkType: soft
@@ -1068,6 +1147,35 @@ __metadata:
   version: 3.0.0
   resolution: "@metamask/safe-event-emitter@npm:3.0.0"
   checksum: 8dc58a76f9f75bf2405931465fc311c68043d851e6b8ebe9f82ae339073a08a83430dba9338f8e3adc4bfc8067607125074bcafa32baee3a5157f42343dc89e5
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "@metamask/utils@npm:5.0.2"
+  dependencies:
+    "@ethereumjs/tx": ^4.1.2
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    semver: ^7.3.8
+    superstruct: ^1.0.3
+  checksum: eca82e42911b2840deb4f32f0f215c5ffd14d22d68afbbe92d3180e920e509e310777b15eab29def3448f3535b66596ceb4c23666ec846adacc8e1bb093ff882
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:1.0.0, @noble/curves@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "@noble/curves@npm:1.0.0"
+  dependencies:
+    "@noble/hashes": 1.3.0
+  checksum: 6bcef44d626c640dc8961819d68dd67dffb907e3b973b7c27efe0ecdd9a5c6ce62c7b9e3dfc930c66605dced7f1ec0514d191c09a2ce98d6d52b66e3315ffa79
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.0, @noble/hashes@npm:^1.3.0, @noble/hashes@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "@noble/hashes@npm:1.3.0"
+  checksum: d7ddb6d7c60f1ce1f87facbbef5b724cdea536fc9e7f59ae96e0fc9de96c8f1a2ae2bdedbce10f7dcc621338dfef8533daa73c873f2b5c87fa1a4e05a95c2e2e
   languageName: node
   linkType: hard
 
@@ -1158,6 +1266,34 @@ __metadata:
     tiny-glob: ^0.2.9
     tslib: ^2.4.0
   checksum: 118a1971120253740121a1db0a6658c21195b7da962acf9c124b507a3df707cfc97b0b84a16edcbd4352853b182e8337da9fc6e8e3d06c60d75ae4fb42321c75
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.1.0":
+  version: 1.1.1
+  resolution: "@scure/base@npm:1.1.1"
+  checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@scure/bip32@npm:1.3.0"
+  dependencies:
+    "@noble/curves": ~1.0.0
+    "@noble/hashes": ~1.3.0
+    "@scure/base": ~1.1.0
+  checksum: 6eae997f9bdf41fe848134898960ac48e645fa10e63d579be965ca331afd0b7c1b8ebac170770d237ab4099dafc35e5a82995384510025ccf2abe669f85e8918
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@scure/bip39@npm:1.2.0"
+  dependencies:
+    "@noble/hashes": ~1.3.0
+    "@scure/base": ~1.1.0
+  checksum: 980d761f53e63de04a9e4db840eb13bfb1bd1b664ecb04a71824c12c190f4972fd84146f3ed89b2a8e4c6bd2c17c15f8b592b7ac029e903323b0f9e2dae6916b
   languageName: node
   linkType: hard
 
@@ -1314,6 +1450,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4.1.7":
+  version: 4.1.8
+  resolution: "@types/debug@npm:4.1.8"
+  dependencies:
+    "@types/ms": "*"
+  checksum: a9a9bb40a199e9724aa944e139a7659173a9b274798ea7efbc277cb084bc37d32fc4c00877c3496fac4fed70a23243d284adb75c00b5fdabb38a22154d18e5df
+  languageName: node
+  linkType: hard
+
 "@types/filesystem@npm:*":
   version: 0.0.30
   resolution: "@types/filesystem@npm:0.0.30"
@@ -1413,6 +1558,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/ms@npm:*":
+  version: 0.7.31
+  resolution: "@types/ms@npm:0.7.31"
+  checksum: daadd354aedde024cce6f5aa873fefe7b71b22cd0e28632a69e8b677aeb48ae8caa1c60e5919bb781df040d116b01cb4316335167a3fc0ef6a63fa3614c0f6da
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:^17.0.23":
   version: 17.0.45
   resolution: "@types/node@npm:17.0.45"
@@ -1471,6 +1623,13 @@ __metadata:
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
   checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
+  languageName: node
+  linkType: hard
+
+"@types/uuid@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@types/uuid@npm:9.0.1"
+  checksum: c472b8a77cbeded4bc529220b8611afa39bd64677f507838f8083d8aac8033b1f88cb9ddaa2f8589e0dcd2317291d0f6e1379f82d5ceebd6f74f3b4825288e00
   languageName: node
   linkType: hard
 
@@ -2439,6 +2598,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crc-32@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "crc-32@npm:1.2.2"
+  bin:
+    crc32: bin/crc32.njs
+  checksum: ad2d0ad0cbd465b75dcaeeff0600f8195b686816ab5f3ba4c6e052a07f728c3e70df2e3ca9fd3d4484dc4ba70586e161ca5a2334ec8bf5a41bf022a6103ff243
+  languageName: node
+  linkType: hard
+
 "create-require@npm:^1.1.0":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
@@ -3194,6 +3362,18 @@ __metadata:
   dependencies:
     fast-safe-stringify: ^2.0.6
   checksum: 1dbdee8f416090f1d318e17bdee2251d174d73c8faa4286fa364bc51ae9105672045f2d078ec23ca6a2b4b92af7cfbe7fa1ba17ad49e591fc653a363bf8cbab2
+  languageName: node
+  linkType: hard
+
+"ethereum-cryptography@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ethereum-cryptography@npm:2.0.0"
+  dependencies:
+    "@noble/curves": 1.0.0
+    "@noble/hashes": 1.3.0
+    "@scure/bip32": 1.3.0
+    "@scure/bip39": 1.2.0
+  checksum: 958f8aab2d1b32aa759fb27a27877b3647410e8bb9aca7d65d1d477db4864cf7fc46b918eb52a1e246c25e98ee0a35a632c88b496aeaefa13469ee767a76c8db
   languageName: node
   linkType: hard
 
@@ -5089,6 +5269,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"micro-ftch@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "micro-ftch@npm:0.3.1"
+  checksum: 0e496547253a36e98a83fb00c628c53c3fb540fa5aaeaf718438873785afd193244988c09d219bb1802984ff227d04938d9571ef90fe82b48bd282262586aaff
+  languageName: node
+  linkType: hard
+
 "micromatch@npm:^4.0.4":
   version: 4.0.5
   resolution: "micromatch@npm:4.0.5"
@@ -6404,6 +6591,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"superstruct@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "superstruct@npm:1.0.3"
+  checksum: 761790bb111e6e21ddd608299c252f3be35df543263a7ebbc004e840d01fcf8046794c274bcb351bdf3eae4600f79d317d085cdbb19ca05803a4361840cc9bb1
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
@@ -6829,6 +7023,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,7 +1131,6 @@ __metadata:
     ts-node: ^10.7.0
     typedoc: ^0.23.15
     typescript: ~4.8.4
-    uuid: ^9.0.0
     webextension-polyfill: ^0.10.0
   languageName: unknown
   linkType: soft
@@ -7023,15 +7022,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "uuid@npm:9.0.0"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implements [EIP-6963](https://eips.ethereum.org/EIPS/eip-6963) according to the current state of the specification. Adds two new top-level imports,  `eip6963AnnounceProvider` and `eip6963RequestProvider`, used by us and the dapp, respectively.

For reference, here are some `EIP6963ProviderInfo` values that would work for us:
```ts
export const MetaMaskEIP6963ProviderInfo: EIP6963ProviderInfo = {
  uuid: uuid(),
  name: 'MetaMask', // Update depending on the build, probably
  icon: 'https://raw.githubusercontent.com/MetaMask/brand-resources/cb6fd847f3a9cc5e231c749383c3898935e62eab/SVG/metamask-fox.svg', // TODO: Find a shorter URL
};
```

The purpose of the `uuid` field is to help dapps notice if multiple wallets are claiming the same `name`. It needs to be a valid v4 UUID. IMO we should create a UUID at the point where we call `announceProvider` (i.e. the content script for the extension). We could also send it from the background.