### PR TITLE
Remove `pump`

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "fast-deep-equal": "^3.1.3",
     "is-stream": "^2.0.0",
     "json-rpc-middleware-stream": "^4.2.1",
-    "pump": "^3.0.0",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {
@@ -60,7 +59,6 @@
     "@types/chrome": "^0.0.233",
     "@types/jest": "^28.1.6",
     "@types/node": "^17.0.23",
-    "@types/pump": "^1.1.0",
     "@types/readable-stream": "^2.3.15",
     "@types/webextension-polyfill": "^0.10.0",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -4,7 +4,7 @@ import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { Json, JsonRpcParams } from '@metamask/utils';
 import { duplex as isDuplex } from 'is-stream';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
-import pump from 'pump';
+import { pipeline } from 'stream';
 import type { Duplex } from 'stream';
 
 import { BaseProvider, BaseProviderOptions } from './BaseProvider';
@@ -68,7 +68,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
 
     // Set up connectionStream multiplexing
     const mux = new ObjectMultiplex();
-    pump(
+    pipeline(
       connectionStream,
       mux as unknown as Duplex,
       connectionStream,
@@ -82,7 +82,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
       retryOnMessage: 'METAMASK_EXTENSION_CONNECT_CAN_RETRY',
     }) as unknown as JsonRpcConnection;
 
-    pump(
+    pipeline(
       this._jsonRpcConnection.stream,
       mux.createStream(jsonRpcStreamName) as unknown as Duplex,
       this._jsonRpcConnection.stream,
@@ -151,7 +151,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
    * disconnected.
    */
   // eslint-disable-next-line no-restricted-syntax
-  private _handleStreamDisconnect(streamName: string, error: Error) {
+  private _handleStreamDisconnect(streamName: string, error: Error | null) {
     let warningMsg = `MetaMask: Lost connection to "${streamName}".`;
     if (error?.stack) {
       warningMsg += `\n${error.stack}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,7 +1111,6 @@ __metadata:
     "@types/chrome": ^0.0.233
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
-    "@types/pump": ^1.1.0
     "@types/readable-stream": ^2.3.15
     "@types/webextension-polyfill": ^0.10.0
     "@typescript-eslint/eslint-plugin": ^5.43.0
@@ -1135,7 +1134,6 @@ __metadata:
     json-rpc-middleware-stream: ^4.2.1
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
-    pump: ^3.0.0
     rimraf: ^3.0.2
     ts-jest: ^28.0.7
     ts-node: ^10.7.0
@@ -1610,15 +1608,6 @@ __metadata:
   version: 2.7.2
   resolution: "@types/prettier@npm:2.7.2"
   checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
-  languageName: node
-  linkType: hard
-
-"@types/pump@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@types/pump@npm:1.1.0"
-  dependencies:
-    "@types/node": "*"
-  checksum: 12e94dd77fef10e4ed9bd22eeda20a2b6de72424727559d7fb04ad21f51da4486b2aa993c44af98483ef2432692c8111722f10937ffd8e83e459e32c5df118ba
   languageName: node
   linkType: hard
 
@@ -2921,7 +2910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.4":
+"end-of-stream@npm:^1.4.4":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
@@ -5611,7 +5600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
+"once@npm:^1.3.0, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
   dependencies:
@@ -5943,16 +5932,6 @@ __metadata:
   version: 1.9.0
   resolution: "psl@npm:1.9.0"
   checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
-  languageName: node
-  linkType: hard
-
-"pump@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "pump@npm:3.0.0"
-  dependencies:
-    end-of-stream: ^1.1.0
-    once: ^1.3.1
-  checksum: e42e9229fba14732593a718b04cb5e1cfef8254544870997e0ecd9732b189a48e1256e4e5478148ecb47c8511dca2b09eae56b4d0aad8009e6fac8072923cfc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removes `pump` in favor of `pipeline`, which should do the same thing.