### PR TITLE
deps: Update to streams3 API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,13 @@ module.exports = {
     },
 
     {
+      files: ['*.d.ts'],
+      rules: {
+        'import/unambiguous': 'off',
+      },
+    },
+
+    {
       files: ['*.js'],
       parserOptions: {
         ecmaVersion: 2020,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "detect-browser": "^5.2.0",
     "extension-port-stream": "^2.1.1",
     "fast-deep-equal": "^3.1.3",
-    "is-stream": "^3.0.0",
+    "is-stream": "^2.0.0",
     "json-rpc-middleware-stream": "^5.0.1",
     "readable-stream": "^3.6.2",
     "webextension-polyfill": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -38,15 +38,15 @@
   },
   "dependencies": {
     "@metamask/json-rpc-engine": "^7.1.1",
-    "@metamask/object-multiplex": "^1.1.0",
+    "@metamask/object-multiplex": "^2.0.0",
     "@metamask/rpc-errors": "^6.0.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^8.1.0",
     "detect-browser": "^5.2.0",
     "extension-port-stream": "^2.1.1",
     "fast-deep-equal": "^3.1.3",
-    "is-stream": "^2.0.0",
-    "json-rpc-middleware-stream": "^4.2.1",
+    "is-stream": "^3.0.0",
+    "json-rpc-middleware-stream": "^5.0.1",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "test": "jest && jest-it-up",
     "test:watch": "jest --watch"
   },
+  "resolutions": {
+    "extension-port-stream/readable-stream": "^3.6.2"
+  },
   "dependencies": {
     "@metamask/json-rpc-engine": "^7.1.1",
     "@metamask/object-multiplex": "^2.0.0",
@@ -43,7 +46,7 @@
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^8.1.0",
     "detect-browser": "^5.2.0",
-    "extension-port-stream": "^2.1.1",
+    "extension-port-stream": "^3.0.0",
     "fast-deep-equal": "^3.1.3",
     "is-stream": "^2.0.0",
     "json-rpc-middleware-stream": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "fast-deep-equal": "^3.1.3",
     "is-stream": "^3.0.0",
     "json-rpc-middleware-stream": "^5.0.1",
+    "readable-stream": "^3.6.2",
     "webextension-polyfill": "^0.10.0"
   },
   "devDependencies": {
@@ -59,7 +60,6 @@
     "@types/chrome": "^0.0.233",
     "@types/jest": "^28.1.6",
     "@types/node": "^17.0.23",
-    "@types/readable-stream": "^2.3.15",
     "@types/uuid": "^9.0.1",
     "@types/webextension-polyfill": "^0.10.0",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -1,6 +1,6 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Json, JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
-import type { Duplex } from 'stream';
+import type { Duplex } from 'readable-stream';
 
 import { UnvalidatedJsonRpcRequest } from './BaseProvider';
 import messages from './messages';

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -2,10 +2,10 @@ import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { Json, JsonRpcParams } from '@metamask/utils';
-import { duplex as isDuplex } from 'is-stream';
+import { isDuplexStream } from 'is-stream';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
-import { pipeline } from 'stream';
-import type { Duplex } from 'stream';
+import { pipeline } from 'readable-stream';
+import type { Duplex } from 'readable-stream';
 
 import { BaseProvider, BaseProviderOptions } from './BaseProvider';
 import messages from './messages';
@@ -59,7 +59,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
   ) {
     super({ logger, maxEventListeners, rpcMiddleware });
 
-    if (!isDuplex(connectionStream)) {
+    if (!isDuplexStream(connectionStream)) {
       throw new Error(messages.errors.invalidDuplexStream());
     }
 

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -2,7 +2,7 @@ import type { JsonRpcMiddleware } from '@metamask/json-rpc-engine';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { Json, JsonRpcParams } from '@metamask/utils';
-import { isDuplexStream } from 'is-stream';
+import { duplex as isDuplex } from 'is-stream';
 import { createStreamMiddleware } from 'json-rpc-middleware-stream';
 import { pipeline } from 'readable-stream';
 import type { Duplex } from 'readable-stream';
@@ -59,7 +59,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
   ) {
     super({ logger, maxEventListeners, rpcMiddleware });
 
-    if (!isDuplexStream(connectionStream)) {
+    if (!isDuplex(connectionStream)) {
       throw new Error(messages.errors.invalidDuplexStream());
     }
 

--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -1,6 +1,6 @@
 import { detect } from 'detect-browser';
 import PortStream from 'extension-port-stream';
-import { Duplex } from 'stream';
+import { Duplex } from 'readable-stream';
 import type { Runtime } from 'webextension-polyfill';
 
 import config from './external-extension-config.json';

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -1,4 +1,4 @@
-import { Duplex } from 'stream';
+import { Duplex } from 'readable-stream';
 
 import { EIP6963ProviderInfo, announceProvider } from './EIP6963';
 import {

--- a/src/readable-stream.d.ts
+++ b/src/readable-stream.d.ts
@@ -1,0 +1,3 @@
+declare module 'readable-stream' {
+  export { Duplex, pipeline } from 'stream';
+}

--- a/test/mocks/MockConnectionStream.ts
+++ b/test/mocks/MockConnectionStream.ts
@@ -4,7 +4,7 @@ import {
   JsonRpcRequest,
   JsonRpcResponse,
 } from '@metamask/utils';
-import { Duplex } from 'stream';
+import { Duplex } from 'readable-stream';
 
 /**
  * A mock multiplexed JSON-RPC stream that represents the connection from the

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,7 +1108,6 @@ __metadata:
     "@types/chrome": ^0.0.233
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
-    "@types/readable-stream": ^2.3.15
     "@types/uuid": ^9.0.1
     "@types/webextension-polyfill": ^0.10.0
     "@typescript-eslint/eslint-plugin": ^5.43.0
@@ -1132,6 +1131,7 @@ __metadata:
     json-rpc-middleware-stream: ^5.0.1
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
+    readable-stream: ^3.6.2
     rimraf: ^3.0.2
     ts-jest: ^28.0.7
     ts-node: ^10.7.0
@@ -1599,16 +1599,6 @@ __metadata:
   version: 2.7.2
   resolution: "@types/prettier@npm:2.7.2"
   checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
-  languageName: node
-  linkType: hard
-
-"@types/readable-stream@npm:^2.3.15":
-  version: 2.3.15
-  resolution: "@types/readable-stream@npm:2.3.15"
-  dependencies:
-    "@types/node": "*"
-    safe-buffer: ~5.1.1
-  checksum: ec36f525cad09b6c65a1dafcb5ad99b9e2ed824ec49b7aa23180ac427e5d35b8a0706193ecd79ab4253a283ad485ba03d5917a98daaaa144f0ea34f4823e9d82
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,7 +1123,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     extension-port-stream: ^2.1.1
     fast-deep-equal: ^3.1.3
-    is-stream: ^3.0.0
+    is-stream: ^2.0.0
     jest: ^28.1.3
     jest-chrome: ^0.7.1
     jest-environment-jsdom: ^29.5.0
@@ -4226,13 +4226,6 @@ __metadata:
   version: 2.0.0
   resolution: "is-stream@npm:2.0.0"
   checksum: 4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
-  languageName: node
-  linkType: hard
-
-"is-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-stream@npm:3.0.0"
-  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,7 +1121,7 @@ __metadata:
     eslint-plugin-jsdoc: ^39.6.2
     eslint-plugin-node: ^11.1.0
     eslint-plugin-prettier: ^4.2.1
-    extension-port-stream: ^2.1.1
+    extension-port-stream: ^3.0.0
     fast-deep-equal: ^3.1.3
     is-stream: ^2.0.0
     jest: ^28.1.3
@@ -3393,12 +3393,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extension-port-stream@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "extension-port-stream@npm:2.1.1"
+"extension-port-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "extension-port-stream@npm:3.0.0"
   dependencies:
+    readable-stream: ^3.6.2 || ^4.4.2
     webextension-polyfill: ">=0.10.0 <1.0"
-  checksum: aee8bbeb2ed6f69a62f58a89580e0e9002dadb11062edbaedb7bb04cfc5a5e0b0d3980bfeaa1c3ee7e08dec7e5fac26e25497fc2f82000db7653442bd5eca157
+  checksum: 4f51d2258a96154c2d916a8a5425636a2b0817763e9277f7dc378d08b6f050c90d185dbde4313d27cf66ad99d4b3116479f9f699c40358c64cccfa524d2b55bf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1080,14 +1080,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/object-multiplex@npm:^1.1.0":
-  version: 1.2.0
-  resolution: "@metamask/object-multiplex@npm:1.2.0"
+"@metamask/object-multiplex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/object-multiplex@npm:2.0.0"
   dependencies:
-    end-of-stream: ^1.4.4
     once: ^1.4.0
-    readable-stream: ^2.3.3
-  checksum: 7c622639cc164c3b780294d790311e4bcb327faf14626717728022e95da5834f32fe4e242d8f4e7d9b8c2b83f0c76450922786b2f6ef50e777bfe119b78bdab7
+    readable-stream: ^3.6.2
+  checksum: 54baea752a3ac7c2742c376512e00d4902d383e9da8787574d3b21eb0081523309e24e3915a98f3ae0341d65712b6832d2eb7eeb862f4ef0da1ead52dcde5387
   languageName: node
   linkType: hard
 
@@ -1102,7 +1101,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": ^11.0.1
     "@metamask/eslint-config-typescript": ^11.0.0
     "@metamask/json-rpc-engine": ^7.1.1
-    "@metamask/object-multiplex": ^1.1.0
+    "@metamask/object-multiplex": ^2.0.0
     "@metamask/rpc-errors": ^6.0.0
     "@metamask/safe-event-emitter": ^3.0.0
     "@metamask/utils": ^8.1.0
@@ -1125,12 +1124,12 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     extension-port-stream: ^2.1.1
     fast-deep-equal: ^3.1.3
-    is-stream: ^2.0.0
+    is-stream: ^3.0.0
     jest: ^28.1.3
     jest-chrome: ^0.7.1
     jest-environment-jsdom: ^29.5.0
     jest-it-up: ^2.0.2
-    json-rpc-middleware-stream: ^4.2.1
+    json-rpc-middleware-stream: ^5.0.1
     prettier: ^2.7.1
     prettier-plugin-packagejson: ^2.3.0
     rimraf: ^3.0.2
@@ -1149,13 +1148,6 @@ __metadata:
     "@metamask/utils": ^8.0.0
     fast-safe-stringify: ^2.0.6
   checksum: 7e1ee1a98972266af4a34f0bbc842cdc11dc565056f0b8fbc93aa95663a7027eab8ff1fecbe3e09c38a1dc199f8219a6c69b2237015b2fdb8de0e5b35027c3f8
-  languageName: node
-  linkType: hard
-
-"@metamask/safe-event-emitter@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/safe-event-emitter@npm:2.0.0"
-  checksum: 8b717ac5d53df0027c05509f03d0534700b5898dd1c3a53fb2dc4c0499ca5971b14aae67f522d09eb9f509e77f50afa95fdb3eda1afbff8b071c18a3d2905e93
   languageName: node
   linkType: hard
 
@@ -2600,13 +2592,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:~1.0.0":
-  version: 1.0.2
-  resolution: "core-util-is@npm:1.0.2"
-  checksum: 7a4c925b497a2c91421e25bf76d6d8190f0b2359a9200dbeed136e63b2931d6294d3b1893eda378883ed363cd950f44a12a401384c609839ea616befb7927dab
-  languageName: node
-  linkType: hard
-
 "cosmiconfig@npm:^7.0.0":
   version: 7.1.0
   resolution: "cosmiconfig@npm:7.1.0"
@@ -2920,15 +2905,6 @@ __metadata:
   dependencies:
     iconv-lite: ^0.6.2
   checksum: bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
-  languageName: node
-  linkType: hard
-
-"end-of-stream@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "end-of-stream@npm:1.4.4"
-  dependencies:
-    once: ^1.4.0
-  checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
   languageName: node
   linkType: hard
 
@@ -4049,7 +4025,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:^2.0.3":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -4263,6 +4239,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-stream@npm:3.0.0"
+  checksum: 172093fe99119ffd07611ab6d1bcccfe8bc4aa80d864b15f43e63e54b7abc71e779acd69afdb854c4e2a67fdc16ae710e370eda40088d1cfc956a50ed82d8f16
+  languageName: node
+  linkType: hard
+
 "is-string@npm:^1.0.5, is-string@npm:^1.0.7":
   version: 1.0.7
   resolution: "is-string@npm:1.0.7"
@@ -4309,13 +4292,6 @@ __metadata:
   dependencies:
     is-docker: ^2.0.0
   checksum: 20849846ae414997d290b75e16868e5261e86ff5047f104027026fd61d8b5a9b0b3ade16239f35e1a067b3c7cc02f70183cb661010ed16f4b6c7c93dad1b19d8
-  languageName: node
-  linkType: hard
-
-"isarray@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "isarray@npm:1.0.0"
-  checksum: f032df8e02dce8ec565cf2eb605ea939bdccea528dbcf565cdf92bfa2da9110461159d86a537388ef1acef8815a330642d7885b29010e8f7eac967c9993b65ab
   languageName: node
   linkType: hard
 
@@ -5010,13 +4986,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-rpc-middleware-stream@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "json-rpc-middleware-stream@npm:4.2.1"
+"json-rpc-middleware-stream@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "json-rpc-middleware-stream@npm:5.0.1"
   dependencies:
-    "@metamask/safe-event-emitter": ^2.0.0
-    readable-stream: ^2.3.3
-  checksum: 207c34ba2c55ff072864422ba48b03f49dd1bc488f0d9c017c7474d3f2514bd4b1cc14daf5324f96887cdaf8e5c1018701960f55fb45e9c3224e3d7db9f70765
+    "@metamask/json-rpc-engine": ^7.1.1
+    "@metamask/safe-event-emitter": ^3.0.0
+    "@metamask/utils": ^8.1.0
+    readable-stream: ^3.6.2
+  checksum: 1cfb8ef5fbb3daa15015213e380e79f043a4208d6ea5533a99b3f3c8aeb01270bfdce5b37003362745a059edbd418d9ca3548fab5fa83355641be2f392303084
   languageName: node
   linkType: hard
 
@@ -5907,13 +5885,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-nextick-args@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "process-nextick-args@npm:2.0.1"
-  checksum: 1d38588e520dab7cea67cbbe2efdd86a10cc7a074c09657635e34f035277b59fbb57d09d8638346bf7090f8e8ebc070c96fa5fd183b777fff4f5edff5e9466cf
-  languageName: node
-  linkType: hard
-
 "promise-inflight@npm:^1.0.1":
   version: 1.0.1
   resolution: "promise-inflight@npm:1.0.1"
@@ -5996,22 +5967,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.3.3":
-  version: 2.3.7
-  resolution: "readable-stream@npm:2.3.7"
-  dependencies:
-    core-util-is: ~1.0.0
-    inherits: ~2.0.3
-    isarray: ~1.0.0
-    process-nextick-args: ~2.0.0
-    safe-buffer: ~5.1.1
-    string_decoder: ~1.1.1
-    util-deprecate: ~1.0.1
-  checksum: e4920cf7549a60f8aaf694d483a0e61b2a878b969d224f89b3bc788b8d920075132c4b55a7494ee944c7b6a9a0eada28a7f6220d80b0312ece70bbf08eeca755
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -6165,7 +6121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: f2f1f7943ca44a594893a852894055cf619c1fbcb611237fc39e461ae751187e7baf4dc391a72125e0ac4fb2d8c5c0b3c71529622e6a58f46b960211e704903c
@@ -6528,15 +6484,6 @@ __metadata:
   dependencies:
     safe-buffer: ~5.2.0
   checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
-  languageName: node
-  linkType: hard
-
-"string_decoder@npm:~1.1.1":
-  version: 1.1.1
-  resolution: "string_decoder@npm:1.1.1"
-  dependencies:
-    safe-buffer: ~5.1.0
-  checksum: 9ab7e56f9d60a28f2be697419917c50cac19f3e8e6c28ef26ed5f4852289fe0de5d6997d29becf59028556f2c62983790c1d9ba1e2a3cc401768ca12d5183a5b
   languageName: node
   linkType: hard
 
@@ -7005,7 +6952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:~1.0.1":
+"util-deprecate@npm:^1.0.1":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2


### PR DESCRIPTION
#### Changed
- **BREAKING**: Consolidate on streams API v3. All streams are now using and expecting compatibility with `readable-stream@3.x`.
  - https://www.npmjs.com/package/readable-stream#version-3xx
- Update `extension-port-stream` from `^2.1.1` to `^3.0.0`
  - [CHANGELOG](https://github.com/MetaMask/extension-port-stream/blob/main/CHANGELOG.md) 
- Update `json-rpc-middleware-stream` from `^4.2.3` to `^5.0.1`
  - [CHANGELOG](https://github.com/MetaMask/json-rpc-middleware-stream/blob/main/CHANGELOG.md) 
- Update `@metamask/object-multiplex` from `^1.3.0` to `^2.0.0`
  - [CHANGELOG](https://github.com/MetaMask/object-multiplex/blob/main/CHANGELOG.md) 
- Add direct dependency on `readable-stream@^3.6.2`


The package is previously mixing usage of `readable-stream@2`, `readable-stream@3` and Node.js native streams (the API and behavior of which differ depending on Node.js version). This consolidates all internal streams on portable `readable-stream`.