### PR TITLE
Don't send undefined params

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 64.78,
+      branches: 65.11,
       functions: 65.65,
-      lines: 66.66,
-      statements: 66.74,
+      lines: 66.74,
+      statements: 66.81,
     },
   },
 

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -208,11 +208,18 @@ export abstract class BaseProvider extends SafeEventEmitter {
       });
     }
 
+    const payload =
+      params === undefined
+        ? {
+            method,
+          }
+        : {
+            method,
+            params,
+          };
+
     return new Promise<T>((resolve, reject) => {
-      this._rpcRequest(
-        { method, params },
-        getRpcPromiseCallback(resolve, reject),
-      );
+      this._rpcRequest(payload, getRpcPromiseCallback(resolve, reject));
     });
   }
 


### PR DESCRIPTION
`undefined` is not valid JSON and isn't supported by our underlying `json-rpc-engine`.