### PR TITLE
Strip `params` if `null` is passed

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,7 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 65.11,
+      branches: 65.43,
       functions: 65.65,
       lines: 66.74,
       statements: 66.81,

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -209,7 +209,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
     }
 
     const payload =
-      params === undefined
+      params === undefined || params === null
         ? {
             method,
           }


### PR DESCRIPTION
Treat `params: null` the same as `params: undefined`. Stripping it from the input and simplifying the validation further along in the stack.