### PR TITLE
Add `StreamProvider` to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "require": "./dist/index.js",
       "types": "./dist/types/index.d.ts"
     },
+    "./dist/StreamProvider": {
+      "import": "./dist/StreamProvider.mjs",
+      "require": "./dist/StreamProvider.js",
+      "types": "./dist/types/StreamProvider.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",


### PR DESCRIPTION
In Snaps we import `./dist/StreamProvider` for the Snaps execution environment bundles, to avoid adding a lot of unused code to the bundles. After #296 this was no longer possible, so I've re-added support for this. Once we refactor the Snaps execution environments build system to use Webpack we can remove this export again.