### PR TITLE
fix(deps): move webextension-polyfill to peerDeps + devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
     "extension-port-stream": "^3.0.0",
     "fast-deep-equal": "^3.1.3",
     "is-stream": "^2.0.0",
-    "readable-stream": "^3.6.2",
-    "webextension-polyfill": "^0.10.0"
+    "readable-stream": "^3.6.2"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.0",
@@ -105,7 +104,11 @@
     "ts-node": "^10.7.0",
     "tsup": "^7.2.0",
     "typedoc": "^0.23.15",
-    "typescript": "~4.8.4"
+    "typescript": "~4.8.4",
+    "webextension-polyfill": "^0.12.0"
+  },
+  "peerDependencies": {
+    "webextension-polyfill": ">=0.10.0 <1.0"
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "webextension-polyfill": ">=0.10.0 <1.0"
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "packageManager": "yarn@3.2.1",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1304,7 +1304,7 @@ __metadata:
     typescript: ~4.8.4
     webextension-polyfill: ^0.12.0
   peerDependencies:
-    webextension-polyfill: ">=0.10.0 <1.0"
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1302,7 +1302,9 @@ __metadata:
     tsup: ^7.2.0
     typedoc: ^0.23.15
     typescript: ~4.8.4
-    webextension-polyfill: ^0.10.0
+    webextension-polyfill: ^0.12.0
+  peerDependencies:
+    webextension-polyfill: ">=0.10.0 <1.0"
   languageName: unknown
   linkType: soft
 
@@ -7978,10 +7980,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webextension-polyfill@npm:>=0.10.0 <1.0, webextension-polyfill@npm:^0.10.0":
-  version: 0.10.0
-  resolution: "webextension-polyfill@npm:0.10.0"
-  checksum: 4a59036bda571360c2c0b2fb03fe1dc244f233946bcf9a6766f677956c40fd14d270aaa69cdba95e4ac521014afbe4008bfa5959d0ac39f91c990eb206587f91
+"webextension-polyfill@npm:>=0.10.0 <1.0, webextension-polyfill@npm:^0.12.0":
+  version: 0.12.0
+  resolution: "webextension-polyfill@npm:0.12.0"
+  checksum: fc2166c8c9d3f32d7742727394092ff1a1eb19cbc4e5a73066d57f9bff1684e38342b90fabd23981e7295e904c536e8509552a64e989d217dae5de6ddca73532
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `webextension-polyfill` package is only used once for a type-import and assumed in environment. This makes it a `peerDependency` and a `devDependency` instead of a `dependency`. A benefit of this is that users can start using new version without us having to release explicit support for every version bump, besides from being more correct.

`peerDependencies` version is aligning with already used transitive via `extension-port-stream`.

This also upgrades the used version from `webextension-polyfill@0.10.0` to `webextension-polyfill@0.12.0`.


---

### Related
- https://github.com/MetaMask/extension-port-stream/pull/54