### PR TITLE
feat: Modify provider RPC error log severity from `error` to `warn`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ function createErrorMiddleware(
       if (!error) {
         return done();
       }
-      log.debug(`MetaMask - RPC Error: ${error.message}`, error);
+      log.warn(`MetaMask - RPC Error: ${error.message}`, error);
       return done();
     });
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ function createErrorMiddleware(
       if (!error) {
         return done();
       }
-      log.error(`MetaMask - RPC Error: ${error.message}`, error);
+      log.debug(`MetaMask - RPC Error: ${error.message}`, error);
       return done();
     });
   };


### PR DESCRIPTION
The error middleware injected in the provider-side `json-rpc-engine` was calling `log.error()` (in practice, `log` = `console`) every time it observed a JSON-RPC error response.

We received reports that this error log is caught by the monitoring infra of some dapps. It is ultimately the caller's responsibility to handle errors where they call `ethereum.request()`, and they can always `console.error()` at that point themselves. In light of the above, we decrease the severity of our own log statement to `warn`.
