### PR TITLE
refactor: Use named `extension-port-stream` import for Vite compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@metamask/safe-event-emitter": "^3.1.1",
     "@metamask/utils": "^8.3.0",
     "detect-browser": "^5.2.0",
-    "extension-port-stream": "^3.0.0",
+    "extension-port-stream": "^4.1.0",
     "fast-deep-equal": "^3.1.3",
     "is-stream": "^2.0.0",
     "readable-stream": "^3.6.2"

--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -1,5 +1,5 @@
 import { detect } from 'detect-browser';
-import PortStream from 'extension-port-stream';
+import { PortDuplexStream as PortStream } from 'extension-port-stream';
 import type { Duplex } from 'readable-stream';
 import type { Runtime } from 'webextension-polyfill';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,7 +1286,7 @@ __metadata:
     eslint-plugin-n: ^15.7.0
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-promise: ^6.1.1
-    extension-port-stream: ^3.0.0
+    extension-port-stream: ^4.1.0
     fast-deep-equal: ^3.1.3
     is-stream: ^2.0.0
     jest: ^28.1.3
@@ -3854,13 +3854,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extension-port-stream@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "extension-port-stream@npm:3.0.0"
+"extension-port-stream@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "extension-port-stream@npm:4.1.0"
   dependencies:
     readable-stream: ^3.6.2 || ^4.4.2
-    webextension-polyfill: ">=0.10.0 <1.0"
-  checksum: 4f51d2258a96154c2d916a8a5425636a2b0817763e9277f7dc378d08b6f050c90d185dbde4313d27cf66ad99d4b3116479f9f699c40358c64cccfa524d2b55bf
+  peerDependencies:
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: e349277cf65a89c2a6c4f3611f52e0a97497bd2870a4c25aa4ab11b300c48e3013fd95208e3ff6c8494dfb849eed725e7506e59118b1a69e555fa4b67afdbd83
   languageName: node
   linkType: hard
 
@@ -7980,7 +7981,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webextension-polyfill@npm:>=0.10.0 <1.0, webextension-polyfill@npm:^0.12.0":
+"webextension-polyfill@npm:^0.12.0":
   version: 0.12.0
   resolution: "webextension-polyfill@npm:0.12.0"
   checksum: fc2166c8c9d3f32d7742727394092ff1a1eb19cbc4e5a73066d57f9bff1684e38342b90fabd23981e7295e904c536e8509552a64e989d217dae5de6ddca73532


### PR DESCRIPTION
- fix vite import error in development
- https://github.com/vitejs/vite/issues/9703
