### PR TITLE
Bump `@ts-bridge/cli` to `^0.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@metamask/eslint-config-jest": "^12.1.0",
     "@metamask/eslint-config-nodejs": "^12.1.0",
     "@metamask/eslint-config-typescript": "^12.1.0",
-    "@ts-bridge/cli": "^0.1.4",
+    "@ts-bridge/cli": "^0.2.0",
     "@ts-bridge/shims": "^0.1.1",
     "@types/chrome": "^0.0.233",
     "@types/jest": "^28.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,7 +1115,7 @@ __metadata:
     "@metamask/rpc-errors": ^6.2.1
     "@metamask/safe-event-emitter": ^3.1.1
     "@metamask/utils": ^8.3.0
-    "@ts-bridge/cli": ^0.1.4
+    "@ts-bridge/cli": ^0.2.0
     "@ts-bridge/shims": ^0.1.1
     "@types/chrome": ^0.0.233
     "@types/jest": ^28.1.6
@@ -1454,12 +1454,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.1.4":
-  version: 0.1.4
-  resolution: "@ts-bridge/cli@npm:0.1.4"
+"@ts-bridge/cli@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@ts-bridge/cli@npm:0.2.0"
   dependencies:
+    "@ts-bridge/resolver": ^0.1.0
     chalk: ^5.3.0
-    resolve.exports: ^2.0.2
     yargs: ^17.7.2
   peerDependencies:
     "@ts-bridge/shims": ^0.1.1
@@ -1470,7 +1470,14 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: f42e18505d56bd684c4fb15c346a05c2eb11cde36a7f6d5e8d09b69a5638f93b9b42c9063982d698ea1465a746c700edc293677381fbabe42f11924bb4888144
+  checksum: 99217b74183dacd644c6313fceed8a2b930e16521cbca251022a74e489ae0b613a65afb5ff26085462d074f338201bc42d4783436f5c1062cb5ce817d584a0a7
+  languageName: node
+  linkType: hard
+
+"@ts-bridge/resolver@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@ts-bridge/resolver@npm:0.1.0"
+  checksum: f476f47056e104476adb2189c8164e5ec29f4145294604e825b01acf813f7b991178ad1c1339ae10a111b66fc05cdaae641d3694cc7db0c08aa1af64b40a0502
   languageName: node
   linkType: hard
 
@@ -6519,13 +6526,6 @@ __metadata:
   version: 1.1.1
   resolution: "resolve.exports@npm:1.1.1"
   checksum: 485aa10082eb388a569d696e17ad7b16f4186efc97dd34eadd029d95b811f21ffee13b1b733198bb4584dbb3cb296aa6f141835221fb7613b9606b84f1386655
-  languageName: node
-  linkType: hard
-
-"resolve.exports@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "resolve.exports@npm:2.0.2"
-  checksum: 1c7778ca1b86a94f8ab4055d196c7d87d1874b96df4d7c3e67bbf793140f0717fd506dcafd62785b079cd6086b9264424ad634fb904409764c3509c3df1653f2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This bumps `@ts-bridge/cli` to `^0.2.0`, which fixes a bug when importing JSON files (see #339, #340).

Closes #339.