### PR TITLE
Add `/stream-provider` export

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -82,7 +82,7 @@ gen_enforced_field(WorkspaceCwd, 'exports["./package.json"]', './package.json').
 
 % The list of files included in the package must only include files generated
 % during the build step.
-gen_enforced_field(WorkspaceCwd, 'files', ['dist']).
+gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'stream-provider.js']).
 
 % If a dependency is listed under "dependencies", it should not be listed under
 % "devDependencies".

--- a/package.json
+++ b/package.json
@@ -39,13 +39,24 @@
         "default": "./dist/StreamProvider.cjs"
       }
     },
+    "./stream-provider": {
+      "import": {
+        "types": "./dist/StreamProvider.d.mts",
+        "default": "./dist/StreamProvider.mjs"
+      },
+      "require": {
+        "types": "./dist/StreamProvider.d.cts",
+        "default": "./dist/StreamProvider.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist"
+    "dist",
+    "stream-provider.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --clean",

--- a/stream-provider.js
+++ b/stream-provider.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/StreamProvider.cjs');


### PR DESCRIPTION
This adds a new export for `StreamProvider` to the root of the package, i.e., `@metamask/provider/stream-provider`. Since #336 the stream provider is at `./dist/StreamProvider.cjs` (and `.mjs`), but Browserify isn't able to resolve this. For compatibility with Browserify, I've added a `stream-provider.js` to the root, which will be used by Browserify and other tools that don't support package exports.

I haven't removed the previous `./dist/StreamProvider` export for backwards compatibility, but we should consider it deprecated and remove it in the next major release.