### PR TITLE
Remove deprecated properties warning

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 65.43,
+      branches: 64.95,
       functions: 65.65,
-      lines: 66.74,
-      statements: 66.81,
+      lines: 66.04,
+      statements: 66.13,
     },
   },
 

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -1084,16 +1084,6 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
       ).provider;
     });
 
-    it('should warn the first time chainId is accessed', async () => {
-      const consoleWarnSpy = jest.spyOn(globalThis.console, 'warn');
-
-      expect(provider.chainId).toBe('0x5');
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        messages.warnings.chainIdDeprecation,
-      );
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    });
-
     it('should not allow chainId to be modified', () => {
       expect(() => (provider.chainId = '0x539')).toThrow(
         'Cannot set property chainId',
@@ -1115,16 +1105,6 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
       ).provider;
     });
 
-    it('should warn the first time networkVersion is accessed', async () => {
-      const consoleWarnSpy = jest.spyOn(globalThis.console, 'warn');
-
-      expect(provider.networkVersion).toBe('5');
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        messages.warnings.networkVersionDeprecation,
-      );
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    });
-
     it('should not allow networkVersion to be modified', () => {
       expect(() => (provider.networkVersion = '1337')).toThrow(
         'Cannot set property networkVersion',
@@ -1144,16 +1124,6 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
           },
         })
       ).provider;
-    });
-
-    it('should warn the first time selectedAddress is accessed', async () => {
-      const consoleWarnSpy = jest.spyOn(globalThis.console, 'warn');
-
-      expect(provider.selectedAddress).toBe('0xdeadbeef');
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        messages.warnings.selectedAddressDeprecation,
-      );
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should not allow selectedAddress to be modified', () => {

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -34,10 +34,6 @@ export type MetaMaskInpageProviderOptions = {
 } & Partial<Omit<StreamProviderOptions, 'rpcMiddleware'>>;
 
 type SentWarningsState = {
-  // properties
-  chainId: boolean;
-  networkVersion: boolean;
-  selectedAddress: boolean;
   // methods
   enable: boolean;
   experimentalMethods: boolean;
@@ -58,10 +54,6 @@ export const MetaMaskInpageProviderStreamName = 'metamask-provider';
 
 export class MetaMaskInpageProvider extends AbstractStreamProvider {
   protected _sentWarnings: SentWarningsState = {
-    // properties
-    chainId: false,
-    networkVersion: false,
-    selectedAddress: false,
     // methods
     enable: false,
     experimentalMethods: false,
@@ -167,30 +159,18 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
   }
 
   //====================
-  // Deprecated Properties
+  // Read-only Properties
   //====================
 
   get chainId(): string | null {
-    if (!this._sentWarnings.chainId) {
-      this._log.warn(messages.warnings.chainIdDeprecation);
-      this._sentWarnings.chainId = true;
-    }
     return super.chainId;
   }
 
   get networkVersion(): string | null {
-    if (!this._sentWarnings.networkVersion) {
-      this._log.warn(messages.warnings.networkVersionDeprecation);
-      this._sentWarnings.networkVersion = true;
-    }
     return this.#networkVersion;
   }
 
   get selectedAddress(): string | null {
-    if (!this._sentWarnings.selectedAddress) {
-      this._log.warn(messages.warnings.selectedAddressDeprecation);
-      this._sentWarnings.selectedAddress = true;
-    }
     return super.selectedAddress;
   }
 

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -24,10 +24,6 @@ const messages = {
       `MetaMask: Connected to chain with ID "${chainId}".`,
   },
   warnings: {
-    // deprecated properties
-    chainIdDeprecation: `MetaMask: 'ethereum.chainId' is deprecated and may be removed in the future. Please use the 'eth_chainId' RPC method instead.\nFor more information, see: https://github.com/MetaMask/metamask-improvement-proposals/discussions/23`,
-    networkVersionDeprecation: `MetaMask: 'ethereum.networkVersion' is deprecated and may be removed in the future. Please use the 'net_version' RPC method instead.\nFor more information, see: https://github.com/MetaMask/metamask-improvement-proposals/discussions/23`,
-    selectedAddressDeprecation: `MetaMask: 'ethereum.selectedAddress' is deprecated and may be removed in the future. Please use the 'eth_accounts' RPC method instead.\nFor more information, see: https://github.com/MetaMask/metamask-improvement-proposals/discussions/23`,
     // deprecated methods
     enableDeprecation: `MetaMask: 'ethereum.enable()' is deprecated and may be removed in the future. Please use the 'eth_requestAccounts' RPC method instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1102`,
     sendDeprecation: `MetaMask: 'ethereum.send(...)' is deprecated and may be removed in the future. Please use 'ethereum.sendAsync(...)' or 'ethereum.request(...)' instead.\nFor more information, see: https://eips.ethereum.org/EIPS/eip-1193`,


### PR DESCRIPTION
Removes deprecation warnings for `window.ethereum.chainId`, `window.ethereum.networkVersion`, and `window.ethereum.selectedAddress` when accessed for the first time after page load

* Fixes https://github.com/MetaMask/MetaMask-planning/issues/3233
