### PR TITLE
Remove beta and Flask from edge-chromium IDs

### DIFF
--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -55,9 +55,10 @@ export function createExternalExtensionProvider(
 function getExtensionId(typeOrId: ExtensionType) {
   let ids: {
     stable: string;
-    beta: string;
-    flask: string;
+    beta?: string;
+    flask?: string;
   };
+
   switch (browser?.name) {
     case 'edge-chromium':
       ids = config.edgeChromiumIds;
@@ -68,5 +69,6 @@ function getExtensionId(typeOrId: ExtensionType) {
     default:
       ids = config.chromeIds;
   }
+
   return ids[typeOrId as keyof typeof ids] ?? typeOrId;
 }

--- a/src/extension-provider/external-extension-config.json
+++ b/src/extension-provider/external-extension-config.json
@@ -5,9 +5,7 @@
     "flask": "ljfoeinjpaedjfecbmggjgodbgkmjkjk"
   },
   "edgeChromiumIds": {
-    "stable": "ejbalbakoplchlghecdalmeeeajnimhm",
-    "beta": "pbbkamfgmaedccnfkmjcofcecjhfgldn",
-    "flask": "ljfoeinjpaedjfecbmggjgodbgkmjkjk"
+    "stable": "ejbalbakoplchlghecdalmeeeajnimhm"
   },
   "firefoxIds": {
     "stable": "webextension@metamask.io",


### PR DESCRIPTION
We don't publish beta and Flask to the Edge store, only to the Chrome and Firefox stores.