### PR TITLE
feat: add intializeInpageProvider export

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,16 @@
         "default": "./dist/StreamProvider.cjs"
       }
     },
+    "./dist/initializeInpageProvider": {
+      "import": {
+        "types": "./dist/initializeInpageProvider.d.mts",
+        "default": "./dist/initializeInpageProvider.mjs"
+      },
+      "require": {
+        "types": "./dist/initializeInpageProvider.d.cts",
+        "default": "./dist/initializeInpageProvider.cjs"
+      }
+    },
     "./stream-provider": {
       "import": {
         "types": "./dist/StreamProvider.d.mts",


### PR DESCRIPTION
Add package export for `initializeInpageProvider`. Used in mm-extension.

---

### Blocking
- #382
  - https://github.com/MetaMask/core/pull/4769
  - https://github.com/MetaMask/metamask-extension/pull/27923