### PR TITLE
fix: Allow optional `jsonRpcStreamName` for inpage provider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 64.35,
+      branches: 64.65,
       functions: 65.65,
-      lines: 65.21,
-      statements: 65.32,
+      lines: 65.51,
+      statements: 65.61,
     },
   },
 

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -31,7 +31,7 @@ export type MetaMaskInpageProviderOptions = {
   shouldSendMetadata?: boolean;
 
   jsonRpcStreamName?: string | undefined;
-} & Partial<Omit<StreamProviderOptions, 'rpcMiddleware'>>;
+} & Partial<Omit<StreamProviderOptions, 'rpcMiddleware' | 'jsonRpcStreamName'>>;
 
 type SentWarningsState = {
   // methods

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -52,9 +52,6 @@ export function initializeProvider({
   shouldSetOnWindow = true,
   shouldShimWeb3 = false,
 }: InitializeProviderOptions): MetaMaskInpageProvider {
-  if (!jsonRpcStreamName) {
-    throw new Error('Required paramater: jsonRpcStreamName');
-  }
   const provider = new MetaMaskInpageProvider(connectionStream, {
     jsonRpcStreamName,
     logger,


### PR DESCRIPTION
The `MetaMaskInpageProvider` type was mistakenly typed to require the `jsonRpcStreamName` as a constructor parameter, despite the author clearly intending this to be optional. This type error was fixed.

This type error motivated a different bug, which is that validation for `jsonRpcStreamName` was added to `initializeInapgeProvider` in #381, constituting an undocumented breaking change (currently blocking us from updating this package in `metamask-extension`). This validation has been removed now that it's no longer needed.

Fixes #389
