### PR TITLE
feat: Add new export for `initializeInpageProvider`

### DIFF
--- a/constraints.pro
+++ b/constraints.pro
@@ -82,7 +82,7 @@ gen_enforced_field(WorkspaceCwd, 'exports["./package.json"]', './package.json').
 
 % The list of files included in the package must only include files generated
 % during the build step.
-gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'stream-provider.js']).
+gen_enforced_field(WorkspaceCwd, 'files', ['dist', 'initializeInpageProvider.d.ts', 'initializeInpageProvider.js', 'stream-provider.js']).
 
 % If a dependency is listed under "dependencies", it should not be listed under
 % "devDependencies".

--- a/initializeInpageProvider.d.ts
+++ b/initializeInpageProvider.d.ts
@@ -1,0 +1,5 @@
+/* eslint-disable import/extensions */
+
+// Re-exported for compatibility with build tools that don't support the
+// `exports` field in package.json
+export * from './dist/initializeInpageProvider.cjs';

--- a/initializeInpageProvider.js
+++ b/initializeInpageProvider.js
@@ -1,0 +1,5 @@
+/* eslint-disable import/extensions,import/no-unresolved */
+
+// Re-exported for compatibility with build tools that don't support the
+// `exports` field in package.json
+module.exports = require('./dist/initializeInpageProvider.cjs');

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
         "default": "./dist/initializeInpageProvider.cjs"
       }
     },
+    "./dist/initializeInpageProvider.cjs": {
+      "types": "./dist/initializeInpageProvider.d.cts",
+      "default": "./dist/initializeInpageProvider.cjs"
+    },
     "./stream-provider": {
       "import": {
         "types": "./dist/StreamProvider.d.mts",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,15 @@
         "default": "./dist/initializeInpageProvider.cjs"
       }
     },
-    "./dist/initializeInpageProvider.cjs": {
-      "types": "./dist/initializeInpageProvider.d.cts",
-      "default": "./dist/initializeInpageProvider.cjs"
+    "./initializeInpageProvider": {
+      "import": {
+        "types": "./dist/initializeInpageProvider.d.mts",
+        "default": "./dist/initializeInpageProvider.mjs"
+      },
+      "require": {
+        "types": "./dist/initializeInpageProvider.d.cts",
+        "default": "./dist/initializeInpageProvider.cjs"
+      }
     },
     "./stream-provider": {
       "import": {
@@ -70,6 +76,8 @@
   "types": "./dist/index.d.cts",
   "files": [
     "dist",
+    "initializeInpageProvider.d.ts",
+    "initializeInpageProvider.js",
     "stream-provider.js"
   ],
   "scripts": {


### PR DESCRIPTION
Add a new top-level export map entry for `initializeInpageProvider ` that maps correctly onto CJS and ESM builds, and add a fallback JavaScript file at the root of the repository for build systems that don't support export maps.

This gives the best of both worlds: build systems that support exports will behave correctly, and those that don't will get the CJS fallback.

The `metamask-extension` project uses two build systems: one which obeys export maps, one which ignores them (Webpack and browserify respectively). The existing `initializeInpageProvider` export map entry doesn't work for browserify because it's looking for `initializeInpageProvider.js`. The file extension is wrong. This fixes that problem.

This strategy was copied from https://github.com/MetaMask/snaps/blob/cbe55deb75e640c03add1ebf9235d4abd513e9d5/packages/snaps-sdk/jsx.js