### PR TITLE
feat: allow `networkVersion` to be set to `null`. fire connection events based on new `isConnected` property value

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 63.88,
-      functions: 66.08,
-      lines: 68.35,
-      statements: 66.46,
+      branches: 67.58,
+      functions: 68.69,
+      lines: 68.42,
+      statements: 68.45,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,7 +47,7 @@ const baseConfig = {
     global: {
       branches: 63.88,
       functions: 66.08,
-      lines: 68.39,
+      lines: 68.35,
       statements: 66.46,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 67.58,
+      branches: 67.98,
       functions: 68.69,
-      lines: 68.42,
-      statements: 68.45,
+      lines: 68.62,
+      statements: 68.65,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 66.79,
-      functions: 68.69,
-      lines: 68.35,
-      statements: 68.38,
+      branches: 63.88,
+      functions: 66.08,
+      lines: 68.39,
+      statements: 66.46,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 67.98,
+      branches: 68.23,
       functions: 68.69,
-      lines: 68.62,
-      statements: 68.65,
+      lines: 68.68,
+      statements: 68.71,
     },
   },
 

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -1,4 +1,5 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
+import { JsonRpcError } from '@metamask/rpc-errors';
 import type { JsonRpcRequest } from '@metamask/utils';
 import { pipeline } from 'readable-stream';
 
@@ -51,6 +52,7 @@ async function getInitializedProvider({
     chainId = '0x0',
     isUnlocked = true,
     networkVersion = '0',
+    isConnected = true,
   } = {},
   onMethodCalled = [],
 }: {
@@ -81,6 +83,7 @@ async function getInitializedProvider({
             chainId,
             isUnlocked,
             networkVersion,
+            isConnected,
           },
         }),
       );
@@ -777,7 +780,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
       });
     });
 
-    it('handles chain changes when the wallet is unable to resolve networkVersion', async () => {
+    it('handles chain changes with intermittent disconnection', async () => {
       const { provider, connectionStream } = await getInitializedProvider();
 
       // We check this mostly for the readability of this test.
@@ -787,33 +790,125 @@ describe('MetaMaskInpageProvider: RPC', () => {
 
       const emitSpy = jest.spyOn(provider, 'emit');
 
-      await new Promise<void>((resolve, reject) => {
-        provider.once('disconnect', () => {
-          reject();
+      await new Promise<void>((resolve) => {
+        provider.once('disconnect', (error) => {
+          expect((error as any).code).toBe(1013);
+          resolve();
         });
-
-        provider.once('chainChanged', (chainId) => {
-          expect(chainId).toStrictEqual('0x1')
-          resolve()
-        })
 
         connectionStream.notify(MetaMaskInpageProviderStreamName, {
           jsonrpc: '2.0',
           method: 'metamask_chainChanged',
-          // A null networkVersion indicates that the network version could not
-          // be determined for the network. The chainChanged event should still be
-          // emitted in this case.
-          params: { chainId: '0x1', networkVersion: null },
+          params: { chainId: '0x1', networkVersion: '1', isConnected: false },
+        });
+      });
+
+      expect(emitSpy).toHaveBeenCalledTimes(3);
+      expect(emitSpy).toHaveBeenCalledWith('chainChanged', '0x1');
+      expect(emitSpy).toHaveBeenCalledWith('networkChanged', '1');
+      expect(emitSpy).toHaveBeenCalledWith(
+        'disconnect',
+        new JsonRpcError(1013, messages.errors.disconnected()),
+      );
+      emitSpy.mockClear(); // Clear the mock to avoid keeping a count.
+
+      expect(provider.isConnected()).toBe(false);
+      expect(provider.chainId).toBe('0x1');
+      expect(provider.networkVersion).toBe('1');
+
+      await new Promise<void>((resolve) => {
+        provider.once('chainChanged', (newChainId) => {
+          expect(newChainId).toBe('0x2');
+          resolve();
+        });
+
+        connectionStream.notify(MetaMaskInpageProviderStreamName, {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x2', networkVersion: '2', isConnected: false },
         });
       });
 
       expect(emitSpy).toHaveBeenCalledTimes(2);
-      expect(emitSpy).toHaveBeenCalledWith('chainChanged', '0x1')
-      expect(emitSpy).toHaveBeenCalledWith('networkChanged', null)
+      expect(emitSpy).toHaveBeenCalledWith('chainChanged', '0x2');
+      expect(emitSpy).toHaveBeenCalledWith('networkChanged', '2');
+      emitSpy.mockClear(); // Clear the mock to avoid keeping a count.
+
+      expect(provider.isConnected()).toBe(false);
+      expect(provider.chainId).toBe('0x2');
+      expect(provider.networkVersion).toBe('2');
+
+      await new Promise<void>((resolve) => {
+        provider.once('connect', (message) => {
+          expect(message).toStrictEqual({ chainId: '0x2' });
+          resolve();
+        });
+
+        connectionStream.notify(MetaMaskInpageProviderStreamName, {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x2', networkVersion: '2', isConnected: true },
+        });
+      });
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledWith('connect', { chainId: '0x2' });
 
       expect(provider.isConnected()).toBe(true);
-      expect(provider.chainId).toBe('0x1');
-      expect(provider.networkVersion).toBe(null);
+      expect(provider.chainId).toBe('0x2');
+      expect(provider.networkVersion).toBe('2');
+    });
+
+    it('handles chain changes with null networkVersion', async () => {
+      const { provider, connectionStream } = await getInitializedProvider();
+
+      // We check this mostly for the readability of this test.
+      expect(provider.isConnected()).toBe(true);
+      expect(provider.chainId).toBe('0x0');
+      expect(provider.networkVersion).toBe('0');
+
+      const emitSpy = jest.spyOn(provider, 'emit');
+
+      await new Promise<void>((resolve) => {
+        provider.once('networkChanged', (newNetworkId) => {
+          expect(newNetworkId).toBeNull();
+          resolve();
+        });
+
+        connectionStream.notify(MetaMaskInpageProviderStreamName, {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x0', networkVersion: null, isConnected: true },
+        });
+      });
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledWith('networkChanged', null);
+      emitSpy.mockClear(); // Clear the mock to avoid keeping a count.
+
+      expect(provider.isConnected()).toBe(true);
+      expect(provider.chainId).toBe('0x0');
+      expect(provider.networkVersion).toBeNull();
+
+      await new Promise<void>((resolve) => {
+        provider.once('networkChanged', (newNetworkId) => {
+          expect(newNetworkId).toBe('1');
+          resolve();
+        });
+
+        connectionStream.notify(MetaMaskInpageProviderStreamName, {
+          jsonrpc: '2.0',
+          method: 'metamask_chainChanged',
+          params: { chainId: '0x0', networkVersion: '1', isConnected: true },
+        });
+      });
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      expect(emitSpy).toHaveBeenCalledWith('networkChanged', '1');
+
+      expect(provider.isConnected()).toBe(true);
+      expect(provider.chainId).toBe('0x0');
+      expect(provider.networkVersion).toBe('1');
     });
   });
 
@@ -1017,6 +1112,7 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
             chainId: '0x0',
             isUnlocked: true,
             networkVersion: '0',
+            isConnected: true,
           };
         });
 

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -859,7 +859,7 @@ describe('MetaMaskInpageProvider: RPC', () => {
       expect(provider.networkVersion).toBe('2');
     });
 
-    it('handles chain changes with null networkVersion', async () => {
+    it('handles chain changes when networkVersion is "loading" by interpreting it as null', async () => {
       const { provider, connectionStream } = await getInitializedProvider();
 
       // We check this mostly for the readability of this test.
@@ -878,7 +878,11 @@ describe('MetaMaskInpageProvider: RPC', () => {
         connectionStream.notify(MetaMaskInpageProviderStreamName, {
           jsonrpc: '2.0',
           method: 'metamask_chainChanged',
-          params: { chainId: '0x0', networkVersion: null, isConnected: true },
+          params: {
+            chainId: '0x0',
+            networkVersion: 'loading',
+            isConnected: true,
+          },
         });
       });
 

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -471,8 +471,15 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
   } = {}) {
     super._handleChainChanged({ chainId, networkVersion, isConnected });
 
-    if (networkVersion !== this.#networkVersion) {
-      this.#networkVersion = networkVersion as string;
+    // The wallet will send a value of `loading` for `networkVersion` when it intends
+    // to communicate that this value cannot be resolved and should be intepreted as null.
+    // The wallet cannot directly send a null value for `networkVersion` because this
+    // would be a breaking change for existing dapps that use their own embedded MetaMask provider.
+    const targetNetworkVersion =
+      networkVersion === 'loading' ? null : networkVersion;
+
+    if (targetNetworkVersion !== this.#networkVersion) {
+      this.#networkVersion = targetNetworkVersion as string;
       if (this._state.initialized) {
         this.emit('networkChanged', this.#networkVersion);
       }

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -450,9 +450,12 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
   }
 
   /**
-   * Upon receipt of a new chainId and networkVersion, emits corresponding
-   * events and sets relevant public state. Does nothing if neither the chainId
-   * nor the networkVersion are different from existing values.
+   * Upon receipt of a new chainId, networkVersion, and isConnected value
+   * emits corresponding events and sets relevant public state. We interpret
+   * a `networkVersion` with the value of `loading` to be null. The `isConnected`
+   * value determines if a `connect` or recoverable `disconnect` has occurred.
+   * Child classes that use the `networkVersion` for other purposes must implement
+   * additional handling therefore.
    *
    * @fires MetamaskInpageProvider#networkChanged
    * @param networkInfo - An object with network info.
@@ -474,7 +477,9 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
     // The wallet will send a value of `loading` for `networkVersion` when it intends
     // to communicate that this value cannot be resolved and should be intepreted as null.
     // The wallet cannot directly send a null value for `networkVersion` because this
-    // would be a breaking change for existing dapps that use their own embedded MetaMask provider.
+    // would be a breaking change for existing dapps that use their own embedded MetaMask provider
+    // that expect this value to always be a integer string or the value 'loading'.
+
     const targetNetworkVersion =
       networkVersion === 'loading' ? null : networkVersion;
 

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -463,8 +463,6 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
     chainId,
     networkVersion,
   }: { chainId?: string; networkVersion?: string } = {}) {
-    // This will validate the params and disconnect the provider if the
-    // networkVersion is 'loading'.
     super._handleChainChanged({ chainId, networkVersion });
 
     if (this._state.isConnected && networkVersion !== this.#networkVersion) {

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -458,14 +458,20 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
    * @param networkInfo - An object with network info.
    * @param networkInfo.chainId - The latest chain ID.
    * @param networkInfo.networkVersion - The latest network ID.
+   * @param networkInfo.isConnected - Whether the network is available.
    */
   protected _handleChainChanged({
     chainId,
     networkVersion,
-  }: { chainId?: string; networkVersion?: string } = {}) {
-    super._handleChainChanged({ chainId, networkVersion });
+    isConnected,
+  }: {
+    chainId?: string;
+    networkVersion?: string;
+    isConnected?: boolean;
+  } = {}) {
+    super._handleChainChanged({ chainId, networkVersion, isConnected });
 
-    if (this._state.isConnected && networkVersion !== this.#networkVersion) {
+    if (networkVersion !== this.#networkVersion) {
       this.#networkVersion = networkVersion as string;
       if (this._state.initialized) {
         this.emit('networkChanged', this.#networkVersion);

--- a/src/StreamProvider.test.ts
+++ b/src/StreamProvider.test.ts
@@ -387,6 +387,7 @@ describe('StreamProvider', () => {
               chainId: '0x0',
               isUnlocked: true,
               networkVersion: '0',
+              isConnected: true,
             };
           });
 
@@ -402,7 +403,7 @@ describe('StreamProvider', () => {
           mockStream.notify(mockStreamName, {
             jsonrpc: '2.0',
             method: 'metamask_chainChanged',
-            params: { chainId: '0x1', networkVersion: '0x1' },
+            params: { chainId: '0x1', networkVersion: '0' },
           });
         });
       });

--- a/src/StreamProvider.test.ts
+++ b/src/StreamProvider.test.ts
@@ -66,6 +66,32 @@ describe('StreamProvider', () => {
         method: 'metamask_getProviderState',
       });
     });
+
+    it('throws if initialized twice', async () => {
+      const accounts = ['0xabc'];
+      const chainId = '0x1';
+      const networkVersion = '1';
+      const isUnlocked = true;
+      const isConnected = true;
+
+      const streamProvider = new StreamProvider(new MockConnectionStream());
+
+      jest.spyOn(streamProvider, 'request').mockImplementation(async () => {
+        return {
+          accounts,
+          chainId,
+          isUnlocked,
+          networkVersion,
+          isConnected,
+        };
+      });
+
+      await streamProvider.initialize();
+
+      await expect(async () => streamProvider.initialize()).rejects.toThrow(
+        new Error('Provider already initialized.'),
+      );
+    });
   });
 
   describe('RPC', () => {

--- a/src/StreamProvider.test.ts
+++ b/src/StreamProvider.test.ts
@@ -404,7 +404,7 @@ describe('StreamProvider', () => {
         });
       });
 
-      it('handles chain changes with intermittent disconnection', async () => {
+      it('handles chain changes when the wallet is unable to resolve networkVersion', async () => {
         const mockStream = new MockConnectionStream();
         const mux = new ObjectMultiplex();
         pipeline(mockStream, mux, mockStream, (error: Error | null) => {
@@ -434,50 +434,28 @@ describe('StreamProvider', () => {
 
         const emitSpy = jest.spyOn(streamProvider, 'emit');
 
-        await new Promise<void>((resolve) => {
-          streamProvider.once('disconnect', (error) => {
-            expect(error.code).toBe(1013);
-            resolve();
+        await new Promise<void>((resolve, reject) => {
+          streamProvider.once('disconnect', () => {
+            reject();
           });
+
+          streamProvider.once('chainChanged', (chainId) => {
+            expect(chainId).toStrictEqual('0x1')
+            resolve()
+          })
 
           mockStream.notify(mockStreamName, {
             jsonrpc: '2.0',
             method: 'metamask_chainChanged',
-            // A "loading" networkVersion indicates the network is changing.
-            // Although the chainId is different, chainChanged should not be
-            // emitted in this case.
-            params: { chainId: '0x1', networkVersion: 'loading' },
+          // A null networkVersion indicates that the network version could not
+          // be determined for the network. The chainChanged event should still be
+          // emitted in this case.
+          params: { chainId: '0x1', networkVersion: null },
           });
         });
 
-        // Only once, for "disconnect".
         expect(emitSpy).toHaveBeenCalledTimes(1);
-        emitSpy.mockClear(); // Clear the mock to avoid keeping a count.
-
-        expect(streamProvider.isConnected()).toBe(false);
-        // These should be unchanged.
-        expect(streamProvider.chainId).toBe('0x0');
-
-        await new Promise<void>((resolve) => {
-          streamProvider.once('chainChanged', (newChainId) => {
-            expect(newChainId).toBe('0x1');
-            resolve();
-          });
-
-          mockStream.notify(mockStreamName, {
-            jsonrpc: '2.0',
-            method: 'metamask_chainChanged',
-            // The networkVersion will be ignored here, we're just setting it
-            // to something other than 'loading'.
-            params: { chainId: '0x1', networkVersion: '1' },
-          });
-        });
-
-        expect(emitSpy).toHaveBeenCalledTimes(2);
-        expect(emitSpy).toHaveBeenNthCalledWith(1, 'connect', {
-          chainId: '0x1',
-        });
-        expect(emitSpy).toHaveBeenCalledWith('chainChanged', '0x1');
+        expect(emitSpy).toHaveBeenCalledWith('chainChanged', '0x1')
 
         expect(streamProvider.isConnected()).toBe(true);
         expect(streamProvider.chainId).toBe('0x1');

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -151,12 +151,8 @@ export abstract class AbstractStreamProvider extends BaseProvider {
 
   /**
    * Upon receipt of a new chainId and networkVersion, emits corresponding
-   * events and sets relevant public state. This class does not have a
-   * `networkVersion` property, but we rely on receiving a `networkVersion`
-   * with the value of `loading` to detect when the network is changing and
-   * a recoverable `disconnect` even has occurred. Child classes that use the
-   * `networkVersion` for other purposes must implement additional handling
-   * therefore.
+   * events and sets relevant public state. Child classes that use the
+   * `networkVersion` for other purposes must implement additional handling.
    *
    * @fires BaseProvider#chainChanged
    * @param networkInfo - An object with network info.
@@ -178,11 +174,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
       return;
     }
 
-    if (networkVersion === 'loading') {
-      this._handleDisconnect(true);
-    } else {
-      super._handleChainChanged({ chainId });
-    }
+    super._handleChainChanged({ chainId });
   }
 }
 

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -158,13 +158,16 @@ export abstract class AbstractStreamProvider extends BaseProvider {
    * @param networkInfo - An object with network info.
    * @param networkInfo.chainId - The latest chain ID.
    * @param networkInfo.networkVersion - The latest network ID.
+   * @param networkInfo.isConnected - Whether the network is available.
    */
   protected _handleChainChanged({
     chainId,
     networkVersion,
+    isConnected,
   }: {
     chainId?: string | undefined;
     networkVersion?: string | undefined;
+    isConnected?: boolean | undefined;
   } = {}) {
     if (!isValidChainId(chainId) || !isValidNetworkVersion(networkVersion)) {
       this._log.error(messages.errors.invalidNetworkParams(), {
@@ -174,7 +177,11 @@ export abstract class AbstractStreamProvider extends BaseProvider {
       return;
     }
 
-    super._handleChainChanged({ chainId });
+    super._handleChainChanged({ chainId, isConnected });
+
+    if (!isConnected) {
+      this._handleDisconnect(true);
+    }
   }
 }
 

--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -45,6 +45,7 @@ async function getInitializedProvider({
     chainId = '0x0',
     isUnlocked = true,
     networkVersion = '0',
+    isConnected = true,
   } = {},
   onMethodCalled = [],
 }: {
@@ -73,6 +74,7 @@ async function getInitializedProvider({
             chainId,
             isUnlocked,
             networkVersion,
+            isConnected
           },
         }),
       );

--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -74,7 +74,7 @@ async function getInitializedProvider({
             chainId,
             isUnlocked,
             networkVersion,
-            isConnected
+            isConnected,
           },
         }),
       );

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -23,14 +23,14 @@ describe('utils', () => {
         '1',
         '10',
         '999',
-        'loading', // this is a hack that we use
+        null
       ].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(true);
       });
     });
 
     it('returns `false` for invalid values', () => {
-      ['', null, undefined, true, 2, 0x1, {}].forEach((value) => {
+      ['', undefined, true, 2, 0x1, {}].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(false);
       });
     });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -19,13 +19,18 @@ describe('utils', () => {
 
   describe('isValidNetworkVersion', () => {
     it('returns `true` for valid values', () => {
-      ['0', '1', '10', '999', null].forEach((value) => {
+      [
+        '1',
+        '10',
+        '999',
+        'loading', // this is a hack that we use
+      ].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(true);
       });
     });
 
     it('returns `false` for invalid values', () => {
-      ['', undefined, true, 2, 0x1, {}].forEach((value) => {
+      ['', null, undefined, true, 2, 0x1, {}].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(false);
       });
     });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
 
   describe('isValidNetworkVersion', () => {
     it('returns `true` for valid values', () => {
-      ['1', '10', '999', null].forEach((value) => {
+      ['0', '1', '10', '999', null].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(true);
       });
     });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -19,12 +19,7 @@ describe('utils', () => {
 
   describe('isValidNetworkVersion', () => {
     it('returns `true` for valid values', () => {
-      [
-        '1',
-        '10',
-        '999',
-        null
-      ].forEach((value) => {
+      ['1', '10', '999', null].forEach((value) => {
         expect(isValidNetworkVersion(value)).toBe(true);
       });
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 
 /**
  * Checks whether the given network version is valid, meaning if it is non-empty
- * string when available or the value 'loading' otherwise.
+ * integer string or the value 'loading'.
  *
  * @param networkVersion - The network version to validate.
  * @returns Whether the given network version is valid.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,6 +112,7 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 export const isValidNetworkVersion = (
   networkVersion: unknown,
 ): networkVersion is string | null =>
-  (Boolean(networkVersion) && typeof networkVersion === 'string') || networkVersion === null
+  (Boolean(networkVersion) && typeof networkVersion === 'string') ||
+  networkVersion === null;
 
 export const NOOP = () => undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -107,7 +107,7 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 
 /**
  * Checks whether the given network version is valid, meaning if it is non-empty
- * string when available or null otherwise.
+ * string when available or the value 'loading' otherwise.
  *
  * @param networkVersion - The network version to validate.
  * @returns Whether the given network version is valid.
@@ -115,8 +115,7 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 export const isValidNetworkVersion = (
   networkVersion: unknown,
 ): networkVersion is string | null =>
-  (typeof networkVersion === 'string' &&
-    POSITIVE_INTEGER_REGEX.test(networkVersion)) ||
-  networkVersion === null;
+  typeof networkVersion === 'string' &&
+  (POSITIVE_INTEGER_REGEX.test(networkVersion) || networkVersion === 'loading');
 
 export const NOOP = () => undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -104,14 +104,14 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 
 /**
  * Checks whether the given network version is valid, meaning if it is non-empty
- * string.
+ * string or null.
  *
  * @param networkVersion - The network version to validate.
  * @returns Whether the given network version is valid.
  */
 export const isValidNetworkVersion = (
   networkVersion: unknown,
-): networkVersion is string =>
-  Boolean(networkVersion) && typeof networkVersion === 'string';
+): networkVersion is string | null =>
+  (Boolean(networkVersion) && typeof networkVersion === 'string') || networkVersion === null
 
 export const NOOP = () => undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,9 @@ export const UUID_V4_REGEX =
 export const FQDN_REGEX =
   /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$)/u;
 
+// https://stackoverflow.com/a/9523559
+const POSITIVE_INTEGER_REGEX = /^(\d*[1-9]\d*|0)$/u;
+
 export const EMITTED_NOTIFICATIONS = Object.freeze([
   'eth_subscription', // per eth-json-rpc-filters/subscriptionManager
 ]);
@@ -104,7 +107,7 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 
 /**
  * Checks whether the given network version is valid, meaning if it is non-empty
- * string or null.
+ * string when available or null otherwise.
  *
  * @param networkVersion - The network version to validate.
  * @returns Whether the given network version is valid.
@@ -112,7 +115,8 @@ export const isValidChainId = (chainId: unknown): chainId is string =>
 export const isValidNetworkVersion = (
   networkVersion: unknown,
 ): networkVersion is string | null =>
-  (Boolean(networkVersion) && typeof networkVersion === 'string') ||
+  (typeof networkVersion === 'string' &&
+    POSITIVE_INTEGER_REGEX.test(networkVersion)) ||
   networkVersion === null;
 
 export const NOOP = () => undefined;


### PR DESCRIPTION
* **BREAKING**: Interprets the provider's `networkVersion` value of `loading` to be null and for the `networkChanged` event to emit a null value
* **BREAKING**: Removes disconnect event/behavior when receiving the `loading` value for `networkVersion` and replaces it with a check against `isConnected` that is now expected in the `metamask_getProviderState` result and `metamask_chainChanged` event

Extension: https://github.com/MetaMask/metamask-extension/pull/29936
See: https://github.com/orgs/MetaMask/projects/146/views/1?filterQuery=label%3A%22team-wallet-api-platform%22+-status%3ABacklog&pane=issue&itemId=95374156&issue=MetaMask%7CMetaMask-planning%7C4039