### PR TITLE
fix: eth_accounts / accountsChanged behavior when wallet is locked

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,7 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 66.79,
+      branches: 67.47,
       functions: 68.42,
       lines: 68.32,
       statements: 68.35,

--- a/jest.config.js
+++ b/jest.config.js
@@ -46,9 +46,9 @@ const baseConfig = {
   coverageThreshold: {
     global: {
       branches: 66.79,
-      functions: 68.69,
-      lines: 68.35,
-      statements: 68.38,
+      functions: 68.42,
+      lines: 68.32,
+      statements: 68.35,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 67.47,
-      functions: 68.42,
-      lines: 68.32,
-      statements: 68.35,
+      branches: 69.23,
+      functions: 69.64,
+      lines: 69.23,
+      statements: 69.38,
     },
   },
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 69.23,
-      functions: 69.64,
-      lines: 69.23,
-      statements: 69.38,
+      branches: 69.63,
+      functions: 71.42,
+      lines: 70.27,
+      statements: 70.4,
     },
   },
 

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -251,7 +251,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
     }
 
     if (initialState) {
-      const { accounts, chainId, isUnlocked, networkVersion } = initialState;
+      const { accounts, chainId, networkVersion } = initialState;
 
       // EIP-1193 connect
       this._handleConnect(chainId);

--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -129,7 +129,6 @@ export abstract class BaseProvider extends SafeEventEmitter {
     this._handleConnect = this._handleConnect.bind(this);
     this._handleChainChanged = this._handleChainChanged.bind(this);
     this._handleDisconnect = this._handleDisconnect.bind(this);
-    this._handleUnlockStateChanged = this._handleUnlockStateChanged.bind(this);
     this._rpcRequest = this._rpcRequest.bind(this);
     this.request = this.request.bind(this);
 
@@ -257,7 +256,6 @@ export abstract class BaseProvider extends SafeEventEmitter {
       // EIP-1193 connect
       this._handleConnect(chainId);
       this._handleChainChanged({ chainId, networkVersion });
-      this._handleUnlockStateChanged({ accounts, isUnlocked });
       this._handleAccountsChanged(accounts);
     }
 
@@ -453,35 +451,6 @@ export abstract class BaseProvider extends SafeEventEmitter {
         const _nextAccounts = [..._accounts];
         this.emit('accountsChanged', _nextAccounts);
       }
-    }
-  }
-
-  /**
-   * Upon receipt of a new isUnlocked state, sets relevant public state.
-   * Calls the accounts changed handler with the received accounts, or an empty
-   * array.
-   *
-   * Does nothing if the received value is equal to the existing value.
-   * There are no lock/unlock events.
-   *
-   * @param opts - Options bag.
-   * @param opts.accounts - The exposed accounts, if any.
-   * @param opts.isUnlocked - The latest isUnlocked value.
-   */
-  protected _handleUnlockStateChanged({
-    accounts,
-    isUnlocked,
-  }: { accounts?: string[]; isUnlocked?: boolean } = {}) {
-    if (typeof isUnlocked !== 'boolean') {
-      this._log.error(
-        'MetaMask: Received invalid isUnlocked parameter. Please report this bug.',
-      );
-      return;
-    }
-
-    if (isUnlocked !== this._state.isUnlocked) {
-      this._state.isUnlocked = isUnlocked;
-      this._handleAccountsChanged(accounts ?? []);
     }
   }
 }

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -1218,4 +1218,25 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
       expect(provider.selectedAddress).toBe('0xdeadbeef');
     });
   });
+
+  describe('_getExperimentalApi', () => {
+    let provider: any | MetaMaskInpageProvider;
+
+    beforeEach(async () => {
+      provider = (
+        await getInitializedProvider({
+          initialState: {
+            accounts: ['0xdeadbeef'],
+          },
+        })
+      ).provider;
+    });
+
+    describe('isUnlocked', () => {
+      it('should return negated value of `state.isPermanentlyDisconnected`', async () => {
+        const isUnlocked = await provider._getExperimentalApi().isUnlocked();
+        expect(isUnlocked).toBe(!provider._state.isPermanentlyDisconnected);
+      });
+    });
+  });
 });

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -50,7 +50,6 @@ async function getInitializedProvider({
   initialState: {
     accounts = [],
     chainId = '0x0',
-    isUnlocked = true,
     networkVersion = '0',
     isConnected = true,
   } = {},
@@ -81,7 +80,6 @@ async function getInitializedProvider({
           result: {
             accounts,
             chainId,
-            isUnlocked,
             networkVersion,
             isConnected,
           },
@@ -1114,7 +1112,6 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
           return {
             accounts: ['0xabc'],
             chainId: '0x0',
-            isUnlocked: true,
             networkVersion: '0',
             isConnected: true,
           };

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -409,14 +409,7 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
          *
          * @returns Promise resolving to true if MetaMask is currently unlocked.
          */
-        isUnlocked: async () => {
-          if (!this._state.initialized) {
-            await new Promise<void>((resolve) => {
-              this.on('_initialized', () => resolve());
-            });
-          }
-          return this._state.isUnlocked;
-        },
+        isUnlocked: async () => !this._state.isPermanentlyDisconnected,
 
         /**
          * Make a batch RPC request.

--- a/src/StreamProvider.test.ts
+++ b/src/StreamProvider.test.ts
@@ -38,7 +38,6 @@ describe('StreamProvider', () => {
       const accounts = ['0xabc'];
       const chainId = '0x1';
       const networkVersion = '1';
-      const isUnlocked = true;
       const isConnected = true;
 
       const streamProvider = new StreamProvider(new MockConnectionStream());
@@ -49,7 +48,6 @@ describe('StreamProvider', () => {
           return {
             accounts,
             chainId,
-            isUnlocked,
             networkVersion,
             isConnected,
           };
@@ -71,7 +69,6 @@ describe('StreamProvider', () => {
       const accounts = ['0xabc'];
       const chainId = '0x1';
       const networkVersion = '1';
-      const isUnlocked = true;
       const isConnected = true;
 
       const streamProvider = new StreamProvider(new MockConnectionStream());
@@ -80,7 +77,6 @@ describe('StreamProvider', () => {
         return {
           accounts,
           chainId,
-          isUnlocked,
           networkVersion,
           isConnected,
         };
@@ -411,7 +407,6 @@ describe('StreamProvider', () => {
             return {
               accounts: [],
               chainId: '0x0',
-              isUnlocked: true,
               networkVersion: '0',
               isConnected: true,
             };
@@ -450,7 +445,6 @@ describe('StreamProvider', () => {
             return {
               accounts: [],
               chainId: '0x0',
-              isUnlocked: true,
               networkVersion: '0',
               isConnected: true,
             };

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -81,8 +81,6 @@ export abstract class AbstractStreamProvider extends BaseProvider {
       const { method, params } = payload;
       if (method === 'metamask_accountsChanged') {
         this._handleAccountsChanged(params);
-      } else if (method === 'metamask_unlockStateChanged') {
-        this._handleUnlockStateChanged(params);
       } else if (method === 'metamask_chainChanged') {
         this._handleChainChanged(params);
       } else if (EMITTED_NOTIFICATIONS.includes(method)) {

--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -43,7 +43,6 @@ async function getInitializedProvider({
   initialState: {
     accounts = [],
     chainId = '0x0',
-    isUnlocked = true,
     networkVersion = '0',
     isConnected = true,
   } = {},
@@ -72,7 +71,6 @@ async function getInitializedProvider({
           result: {
             accounts,
             chainId,
-            isUnlocked,
             networkVersion,
             isConnected,
           },


### PR DESCRIPTION
This PR fixes [#3853](https://github.com/MetaMask/MetaMask-planning/issues/3853):

_Currently when the user locks the wallet (either manually or by timer) the wallet emits an `accountsChanged` event with an empty array to all connected dapps. This is very confusing since it cannot be immediately distinguished from permissions being revoked, resulting in dapps not handling these two cases gracefully._

_We should stop emitting the `accountsChanged` event when the wallet is locked._

This change addresses this by removing `handleUnlockStateChanged` functionality from the `BaseProvider`, as it was decided it does not make sense to announce any account related information when the extension locks/unlocks:

Extensions pull request that will be pulling this change for the fix: https://github.com/MetaMask/metamask-extension/pull/30067

Extension working with updated providers lib:


https://github.com/user-attachments/assets/3fcaaf9f-563a-4d65-9e4a-0dc56cfcb4f5


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
