### PR TITLE
fix BaseProvider._handleChainChanged typing from inheritance

### DIFF
--- a/src/BaseProvider.ts
+++ b/src/BaseProvider.ts
@@ -393,7 +393,7 @@ export abstract class BaseProvider extends SafeEventEmitter {
     isConnected,
   }:
     | {
-        chainId?: string;
+        chainId?: string | undefined;
         networkVersion?: string | undefined;
         isConnected?: boolean | undefined;
       }


### PR DESCRIPTION
Fixes the following error in `main` on `yarn build`

```
src/BaseProvider.ts:262:32 - error TS2379: Argument of type '{ chainId: string; networkVersion: string | undefined; isConnected: boolean | undefined; }' is not assignable to parameter of type '{ chainId?: string; networkVersion?: string | undefined; isConnected?: boolean; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'isConnected' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'boolean'.
      Type 'undefined' is not assignable to type 'boolean'.

262       this._handleChainChanged({ chainId, networkVersion, isConnected });
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/MetaMaskInpageProvider.ts:475:31 - error TS2379: Argument of type '{ chainId: string | undefined; networkVersion: string | undefined; isConnected: boolean | undefined; }' is not assignable to parameter of type '{ chainId?: string; networkVersion?: string | undefined; isConnected?: boolean; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'chainId' are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

475     super._handleChainChanged({ chainId, networkVersion, isConnected });
                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/StreamProvider.ts:180:31 - error TS2379: Argument of type '{ chainId: string; isConnected: boolean | undefined; }' is not assignable to parameter of type '{ chainId?: string; networkVersion?: string | undefined; isConnected?: boolean; }' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Types of property 'isConnected' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'boolean'.
      Type 'undefined' is not assignable to type 'boolean'.

180     super._handleChainChanged({ chainId, isConnected });
                                  ~~~~~~~~~~~~~~~~~~~~~~~~

```