### PR TITLE
feat: remove substream instantiation from `initializeProvider`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,10 +45,10 @@ const baseConfig = {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 69.63,
-      functions: 71.42,
-      lines: 70.27,
-      statements: 70.4,
+      branches: 70.2,
+      functions: 72.07,
+      lines: 71.03,
+      statements: 71.16,
     },
   },
 

--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -15,6 +15,7 @@ export type ExtensionType = 'stable' | 'flask' | 'beta' | string;
 
 /**
  * Creates an external extension provider for the given extension type or ID.
+ * This is intended for use by 3rd party extensions.
  *
  * @param typeOrId - The extension type or ID.
  * @returns The external extension provider.


### PR DESCRIPTION
Removes the responsibility of `metamask-provider` substream instantiation from the `initializeProvider` helper.

extension preview: https://github.com/MetaMask/metamask-extension/pull/31056