### PR TITLE
fix: catch error when ethereum provider is set before our attempt to set

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -47,8 +47,8 @@ const baseConfig = {
     global: {
       branches: 70.68,
       functions: 72.32,
-      lines: 71.27,
-      statements: 71.39,
+      lines: 71.39,
+      statements: 71.51,
     },
   },
 

--- a/src/initializeInpageProvider.test.ts
+++ b/src/initializeInpageProvider.test.ts
@@ -20,6 +20,27 @@ describe('setGlobalProvider', () => {
       new Event('ethereum#initialized'),
     );
   });
+
+  it('should not throw an error if the global ethereum provider is already set', () => {
+    const errorSpy = jest.spyOn(console, 'error');
+
+    const mockProvider = {} as unknown as MetaMaskInpageProvider;
+    Object.defineProperty(window, 'ethereum', {
+      get() {
+        return {};
+      },
+      set() {
+        throw new Error('window.ethereum already set');
+      },
+      configurable: false,
+    });
+    expect(() => setGlobalProvider(mockProvider)).not.toThrow();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'MetaMask encountered an error setting the global Ethereum provider - this is likely due to another Ethereum wallet extension also setting the global Ethereum provider:',
+      expect.any(Error),
+    );
+  });
 });
 
 describe('announceCaip294WalletData', () => {

--- a/src/initializeInpageProvider.ts
+++ b/src/initializeInpageProvider.ts
@@ -98,8 +98,15 @@ export function initializeProvider({
 export function setGlobalProvider(
   providerInstance: MetaMaskInpageProvider,
 ): void {
-  (window as Record<string, any>).ethereum = providerInstance;
-  window.dispatchEvent(new Event('ethereum#initialized'));
+  try {
+    (window as Record<string, any>).ethereum = providerInstance;
+    window.dispatchEvent(new Event('ethereum#initialized'));
+  } catch (error) {
+    console.error(
+      'MetaMask encountered an error setting the global Ethereum provider - this is likely due to another Ethereum wallet extension also setting the global Ethereum provider:',
+      error,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Currently when another wallet (currently only seeing this with Rabby) is installed and gets to the `ethereum` global before us (and [pulls up the ladder behind them](https://github.com/RabbyHub/page-provider/blob/9ea723257defaaa8f00c323715ba388f504b6c2a/src/index.ts#L508)) our provider errors out. This is now downstream causing our Solana Wallet Standard Provider to also fail to register.

Though we cannot overcome this issue we can atleast prevent the subsequent provider registration from failing.

Related: https://github.com/MetaMask/metamask-extension/issues/30685

## Video Demo of Bug
https://github.com/user-attachments/assets/4d26cc8a-dd39-4fe2-a85d-552f69f6fa44


## After
https://github.com/user-attachments/assets/b236b3c7-e9f3-4185-9821-f3239c3d12cd

