### PR TITLE
feat: Enhance CAIP-294 wallet announcement for mobile flask builds

### DIFF
--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -104,6 +104,9 @@ describe('getBuildType', () => {
     { payload: 'io.metamask.beta', expected: 'beta' },
     { payload: 'io.metamask', expected: 'stable' },
     { payload: 'io.metamask.flask', expected: 'flask' },
+    { payload: 'io.metamask.mobile', expected: 'stable' },
+    { payload: 'io.metamask.mobile.beta', expected: 'beta' },
+    { payload: 'io.metamask.mobile.flask', expected: 'flask' },
     { payload: 'io.metamask.unknown', expected: undefined },
   ];
 

--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -94,6 +94,9 @@ export function getBuildType(rdns: string): string | undefined {
     'io.metamask': 'stable',
     'io.metamask.beta': 'beta',
     'io.metamask.flask': 'flask',
+    'io.metamask.mobile': 'stable',
+    'io.metamask.mobile.beta': 'beta',
+    'io.metamask.mobile.flask': 'flask',
   };
   return rndsToIdDefinition[rdns];
 }

--- a/src/initializeInpageProvider.test.ts
+++ b/src/initializeInpageProvider.test.ts
@@ -67,6 +67,19 @@ describe('announceCaip294WalletData', () => {
       expect(getBuildType).toHaveBeenCalledWith(mockProviderInfo.rdns);
       expect(announceWallet).not.toHaveBeenCalled();
     });
+
+    it('should not announce wallet if mobile build type is not flask', async () => {
+      const mobileMockProviderInfo = {
+        ...mockProviderInfo,
+        rdns: 'io.metamask.mobile',
+      };
+      (getBuildType as jest.Mock).mockReturnValue('stable');
+
+      await announceCaip294WalletData(mockProvider, mobileMockProviderInfo);
+
+      expect(getBuildType).toHaveBeenCalledWith(mobileMockProviderInfo.rdns);
+      expect(announceWallet).not.toHaveBeenCalled();
+    });
   });
 
   describe('build type is flask', () => {
@@ -99,6 +112,29 @@ describe('announceCaip294WalletData', () => {
       expect(announceWallet).toHaveBeenCalledWith({
         ...mockProviderInfo,
         targets: [],
+      });
+    });
+
+    it('should announce wallet with caip-348 target for mobile flask', async () => {
+      const extensionId = 'test-extension-id';
+      const mobileMockProviderInfo = {
+        ...mockProviderInfo,
+        rdns: 'io.metamask.mobile.flask',
+      };
+      (getBuildType as jest.Mock).mockReturnValue('flask');
+      (mockProvider.request as jest.Mock).mockReturnValue({ extensionId });
+
+      await announceCaip294WalletData(mockProvider, mobileMockProviderInfo);
+
+      expect(getBuildType).toHaveBeenCalledWith(mobileMockProviderInfo.rdns);
+      expect(announceWallet).toHaveBeenCalledWith({
+        ...mobileMockProviderInfo,
+        targets: [
+          {
+            type: 'caip-348',
+            value: extensionId,
+          },
+        ],
       });
     });
   });


### PR DESCRIPTION
# Description

## Purpose and Impact
This PR improves CAIP-294 wallet announcement logic to support mobile builds, ensuring announcements only occur for 'flask' mobile builds. 

## Key Implementation Details
- Updated `getBuildType` in `src/extension-provider/createExternalExtensionProvider.ts` to map mobile rdns:
  - `io.metamask.mobile` → `stable`
  - `io.metamask.mobile.beta` → `beta`
  - `io.metamask.mobile.flask` → `flask`
- Modified `announceCaip294WalletData` to skip announcements for non-flask mobile builds and include CAIP-348 targets for flask mobile builds.
- Added tests in `src/extension-provider/createExternalExtensionProvider.test.ts` and `src/initializeInpageProvider.test.ts` to verify build type detection and announcement logic.

## Breaking Changes
None. Changes are backward compatible.