### PR TITLE
Pass isInitializingStreamProvider to metamask_getProviderState

### DIFF
--- a/src/StreamProvider.test.ts
+++ b/src/StreamProvider.test.ts
@@ -62,6 +62,7 @@ describe('StreamProvider', () => {
       expect(requestMock).toHaveBeenCalledTimes(1);
       expect(requestMock).toHaveBeenCalledWith({
         method: 'metamask_getProviderState',
+        params: { isInitializingStreamProvider: true },
       });
     });
 

--- a/src/StreamProvider.ts
+++ b/src/StreamProvider.ts
@@ -113,6 +113,7 @@ export abstract class AbstractStreamProvider extends BaseProvider {
     try {
       initialState = (await this.request({
         method: 'metamask_getProviderState',
+        params: { isInitializingStreamProvider: true },
       })) as Parameters<BaseProvider['_initializeState']>[0];
     } catch (error) {
       this._log.error(


### PR DESCRIPTION
In order to initialize the state of the StreamProvider, `metamask_getProviderState` must be called. In the extension, the current implementation of this RPC method retrieves the network version of the currently selected network via `net_version` and returns it along with other information. This creates a problem, however. Because the StreamProvider must be initialized in order to load the UI, if the network is slow or unresponsive, then users will see an infinite spinner until the request is resolved.

To fix this, we inform the RPC method that the StreamProvider is being initialized. The idea is that for this special case, the extension will opt not to make a request for the network version, returning "loading". For requests for `metamask_getProviderState` outside of StreamProvider this will not be the case and the network version will be retrieved as usual.

This means that StreamProvider will not have a network version initially. However, while they do expect `metamask_getProviderState` to return a `networkVersion` property, neither BaseProvider nor StreamProvider seem to do anything with it (unlike MetaMaskInpageProvider, which tracks it and allows dapps to read it).

---

Related to https://github.com/MetaMask/metamask-extension/issues/34214.

Also see https://github.com/MetaMask/metamask-extension/pull/35516 where this parameter is being used.