### PR TITLE
fix: prevent "document is not defined" error in non-DOM environments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,8 @@ module.exports = {
         'EIP6963.test.ts',
         'CAIP294.test.ts',
         'initializeInpageProvider.test.ts',
+        'MetaMaskInpageProvider.test.ts',
+        'siteMetadata.test.ts',
         'jest.setup.browser.js',
       ],
       rules: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent `document is not defined` error when constructing the provider in non-DOM environments, such as extension background pages and service workers ([#428](https://github.com/MetaMask/providers/pull/428))
+
 ## [22.1.1]
 
 ### Changed

--- a/jest.config.js
+++ b/jest.config.js
@@ -227,6 +227,7 @@ const browserConfig = {
     '**/*ExtensionProvider.test.ts',
     '**/EIP6963.test.ts',
     '**/CAIP294.test.ts',
+    '**/siteMetadata.test.ts',
   ],
   setupFilesAfterEnv: ['./jest.setup.browser.js'],
 };

--- a/src/MetaMaskInpageProvider.test.ts
+++ b/src/MetaMaskInpageProvider.test.ts
@@ -8,6 +8,7 @@ import {
   MetaMaskInpageProviderStreamName,
   MetaMaskInpageProvider,
 } from './MetaMaskInpageProvider';
+import * as siteMetadata from './siteMetadata';
 import { MockConnectionStream } from '../test/mocks/MockConnectionStream';
 
 /**
@@ -1126,6 +1127,62 @@ describe('MetaMaskInpageProvider: Miscellanea', () => {
       expect(inpageProvider.networkVersion).toBe('0');
       expect(inpageProvider.selectedAddress).toBe('0xabc');
       expect(inpageProvider.isConnected()).toBe(true);
+    });
+
+    describe('site metadata', () => {
+      it('sends site metadata immediately if the document has already loaded', () => {
+        const sendSiteMetadataSpy = jest
+          .spyOn(siteMetadata, 'sendSiteMetadata')
+          .mockResolvedValue(undefined);
+
+        expect(
+          () =>
+            new MetaMaskInpageProvider(new MockConnectionStream(), {
+              shouldSendMetadata: true,
+            }),
+        ).not.toThrow();
+
+        expect(sendSiteMetadataSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends site metadata on DOMContentLoaded if the document is still loading', () => {
+        const sendSiteMetadataSpy = jest
+          .spyOn(siteMetadata, 'sendSiteMetadata')
+          .mockResolvedValue(undefined);
+        jest
+          .spyOn(globalThis.document, 'readyState', 'get')
+          .mockReturnValue('loading');
+
+        expect(
+          () =>
+            new MetaMaskInpageProvider(new MockConnectionStream(), {
+              shouldSendMetadata: true,
+            }),
+        ).not.toThrow();
+        expect(sendSiteMetadataSpy).not.toHaveBeenCalled();
+
+        globalThis.window.dispatchEvent(new Event('DOMContentLoaded'));
+        expect(sendSiteMetadataSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends site metadata immediately if there is no document, e.g. in an extension background script', () => {
+        const sendSiteMetadataSpy = jest
+          .spyOn(siteMetadata, 'sendSiteMetadata')
+          .mockResolvedValue(undefined);
+        const documentSpy = jest
+          .spyOn(globalThis, 'document', 'get')
+          .mockReturnValue(undefined as unknown as Document);
+
+        expect(
+          () =>
+            new MetaMaskInpageProvider(new MockConnectionStream(), {
+              shouldSendMetadata: true,
+            }),
+        ).not.toThrow();
+        expect(sendSiteMetadataSpy).toHaveBeenCalledTimes(1);
+
+        documentSpy.mockRestore();
+      });
     });
   });
 

--- a/src/MetaMaskInpageProvider.ts
+++ b/src/MetaMaskInpageProvider.ts
@@ -135,7 +135,14 @@ export class MetaMaskInpageProvider extends AbstractStreamProvider {
 
     // send website metadata
     if (shouldSendMetadata) {
-      if (document.readyState === 'complete') {
+      // The `document` global is not available in non-DOM environments, such
+      // as extension background pages and service workers. In such
+      // environments, there is nothing to wait for, so we treat the site
+      // metadata as immediately available.
+      if (
+        typeof document === 'undefined' ||
+        document.readyState === 'complete'
+      ) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         sendSiteMetadata(this._rpcEngine, this._log);
       } else {

--- a/src/siteMetadata.test.ts
+++ b/src/siteMetadata.test.ts
@@ -1,0 +1,50 @@
+import type { JsonRpcEngine } from '@metamask/json-rpc-engine';
+
+import { sendSiteMetadata } from './siteMetadata';
+
+describe('sendSiteMetadata', () => {
+  it('sends site metadata from the DOM', async () => {
+    const meta = globalThis.document.createElement('meta');
+    meta.setAttribute('property', 'og:site_name');
+    meta.content = 'Test Site';
+    globalThis.document.head.appendChild(meta);
+
+    const handle = jest.fn();
+    await sendSiteMetadata({ handle } as unknown as JsonRpcEngine, console);
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'metamask_sendDomainMetadata',
+        params: {
+          name: 'Test Site',
+          icon: null,
+        },
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('falls back to the hostname if there is no document, e.g. in an extension background script', async () => {
+    const documentSpy = jest
+      .spyOn(globalThis, 'document', 'get')
+      .mockReturnValue(undefined as unknown as Document);
+
+    const handle = jest.fn();
+    await sendSiteMetadata({ handle } as unknown as JsonRpcEngine, console);
+
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'metamask_sendDomainMetadata',
+        params: {
+          name: globalThis.location.hostname,
+          icon: null,
+        },
+      }),
+      expect.any(Function),
+    );
+
+    documentSpy.mockRestore();
+  });
+});

--- a/src/siteMetadata.ts
+++ b/src/siteMetadata.ts
@@ -41,8 +41,8 @@ export async function sendSiteMetadata(
  */
 async function getSiteMetadata() {
   return {
-    name: getSiteName(window),
-    icon: await getSiteIcon(window),
+    name: getSiteName(globalThis),
+    icon: await getSiteIcon(globalThis),
   };
 }
 
@@ -52,8 +52,13 @@ async function getSiteMetadata() {
  * @param windowObject - The window object to extract the site name from.
  * @returns The site name.
  */
-function getSiteName(windowObject: typeof window): string {
+function getSiteName(windowObject: typeof globalThis): string {
   const { document } = windowObject;
+  // The `document` global is not available in non-DOM environments, such as
+  // extension background pages and service workers.
+  if (typeof document === 'undefined') {
+    return windowObject.location.hostname;
+  }
 
   const siteName: HTMLMetaElement | null = document.querySelector(
     'head > meta[property="og:site_name"]',
@@ -73,7 +78,7 @@ function getSiteName(windowObject: typeof window): string {
     return document.title;
   }
 
-  return window.location.hostname;
+  return windowObject.location.hostname;
 }
 
 /**
@@ -83,9 +88,14 @@ function getSiteName(windowObject: typeof window): string {
  * @returns An icon URL, if one exists.
  */
 async function getSiteIcon(
-  windowObject: typeof window,
+  windowObject: typeof globalThis,
 ): Promise<string | null> {
   const { document } = windowObject;
+  // The `document` global is not available in non-DOM environments, such as
+  // extension background pages and service workers.
+  if (typeof document === 'undefined') {
+    return null;
+  }
 
   const icons: NodeListOf<HTMLLinkElement> = document.querySelectorAll(
     'head > link[rel~="icon"]',


### PR DESCRIPTION
## Description

Constructing `MetaMaskInpageProvider` with `shouldSendMetadata` enabled throws a `document is not defined` `ReferenceError` in non-DOM environments (e.g. Chrome extension background scripts / service workers), because the constructor unconditionally reads `document.readyState` and registers a `DOMContentLoaded` listener on `window`.

This PR guards the DOM access:

- `MetaMaskInpageProvider`: if `typeof document === 'undefined'`, the missing document is treated as "already loaded" and the site metadata is sent immediately, instead of reading `document.readyState` / waiting for `DOMContentLoaded`.
- `siteMetadata.ts`: the site name/icon extraction now receives `globalThis` and falls back to `location.hostname` (and a `null` icon) when no `document` is available, so the metadata request no longer fails with an unhandled `ReferenceError` logged as an error. Also fixes a small inconsistency where `getSiteName` read the global `window` instead of its `windowObject` parameter for the hostname fallback.

Behavior in normal window contexts is unchanged.

Fixes #191

## Testing

- `yarn jest` — all 9 suites / 135 tests pass, including new tests:
  - constructor sends site metadata immediately when the document has already loaded
  - constructor waits for `DOMContentLoaded` when the document is still loading
  - constructor does not throw and sends metadata immediately when `document` is `undefined` (simulated by mocking the `document` getter in jsdom)
  - `sendSiteMetadata` sends DOM-derived metadata, and falls back to the hostname when `document` is `undefined`
- `yarn lint:eslint` — passes (the two touched test files were added to the existing mixed-environment `no-restricted-globals` override, following the pattern used for `EIP6963.test.ts` et al.)
- `yarn lint:misc --check` — passes
- `yarn build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive guards on optional metadata sending; normal in-page behavior is preserved and covered by new tests.
> 
> **Overview**
> Fixes **`document is not defined`** when **`MetaMaskInpageProvider`** is created with **`shouldSendMetadata`** in environments without a DOM (extension backgrounds, service workers).
> 
> The constructor now treats a missing **`document`** like a fully loaded page and calls **`sendSiteMetadata`** immediately instead of reading **`document.readyState`** or waiting on **`DOMContentLoaded`**. **`siteMetadata`** extraction uses **`globalThis`** and, when **`document`** is absent, falls back to **`location.hostname`** and a **`null`** icon (and uses the passed object for the hostname fallback instead of the global **`window`**).
> 
> Browser behavior is unchanged; tests cover DOM, loading, and no-document paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9638968496158838cbfafc7dbf623ce6b621562a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->