### PR TITLE
fix: ignore legacy publicConfig stream in createExternalExtensionProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore legacy `publicConfig` stream in `createExternalExtensionProvider` to prevent `ObjectMultiplex - orphaned data for stream "publicConfig"` warnings ([#429](https://github.com/MetaMask/providers/pull/429))
+
 ## [22.1.1]
 
 ### Changed

--- a/src/extension-provider/createExternalExtensionProvider.test.ts
+++ b/src/extension-provider/createExternalExtensionProvider.test.ts
@@ -157,6 +157,23 @@ describe('createExternalExtensionProvider', () => {
     expect(global.chrome.runtime.connect).toHaveBeenCalledWith('foobar');
   });
 
+  it('ignores messages for the legacy publicConfig stream', async () => {
+    const consoleWarnSpy = jest.spyOn(globalThis.console, 'warn');
+    const { port } = await getInitializedProvider();
+
+    port.notify('publicConfig', {
+      jsonrpc: '2.0',
+      method: 'metamask_chainChanged',
+      params: { chainId: '0x1', networkVersion: '1' },
+    });
+    // Wait for the message to propagate through the stream pipeline.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(consoleWarnSpy).not.toHaveBeenCalledWith(
+      'ObjectMultiplex - orphaned data for stream "publicConfig"',
+    );
+  });
+
   describe('RPC warnings', () => {
     const warnings = [
       {

--- a/src/extension-provider/createExternalExtensionProvider.ts
+++ b/src/extension-provider/createExternalExtensionProvider.ts
@@ -11,6 +11,12 @@ import { getDefaultExternalMiddleware } from '../utils';
 
 const browser = detect();
 
+/**
+ * The name of the legacy public config substream. The MetaMask extension
+ * still writes to this stream, but the provider no longer uses it.
+ */
+const LegacyPublicConfigStreamName = 'publicConfig';
+
 export type ExtensionType = 'stable' | 'flask' | 'beta' | string;
 
 /**
@@ -32,6 +38,10 @@ export function createExternalExtensionProvider(
     const pluginStream = new PortStream(metamaskPort);
     const streamName = MetaMaskInpageProviderStreamName;
     const mux = new ObjectMultiplex();
+    // The wallet still writes to the legacy `publicConfig` stream. Ignore it
+    // to avoid "ObjectMultiplex - orphaned data" warnings, mirroring how the
+    // MetaMask extension contentscript ignores legacy streams.
+    mux.ignoreStream(LegacyPublicConfigStreamName);
     pipeline(pluginStream, mux, pluginStream, (error: Error | null) => {
       let warningMsg = `Lost connection to "${streamName}".`;
       if (error?.stack) {


### PR DESCRIPTION
## Description

When connecting to MetaMask via `createExternalExtensionProvider()`, the wallet still writes state updates to the legacy `publicConfig` substream of the multiplexed port connection. The provider side never registers a substream for that name, so `ObjectMultiplex` logs an `ObjectMultiplex - orphaned data for stream "publicConfig"` warning to the consuming extension's console for every message.

The MetaMask extension's own contentscript already solves this for the injected in-page provider by calling `ignoreStream(LEGACY_PUBLIC_CONFIG)` on its multiplexer ([contentscript source](https://github.com/MetaMask/metamask-extension/blob/c40dbb1ec72b91827debb2fffba4097a838f21c7/app/scripts/contentscript.js#L254)), which is why web pages don't see these warnings. This PR applies the same pattern to the external extension provider path: the `ObjectMultiplex` instance created in `createExternalExtensionProvider` now registers `publicConfig` as an ignored substream (`mux.ignoreStream('publicConfig')`) before the pipeline is wired up, so legacy messages are silently dropped instead of warned about.

Fixes #294

## Testing

- Added a unit test in `src/extension-provider/createExternalExtensionProvider.test.ts` that sends a message on the `publicConfig` substream via the existing `MockPort` helper and asserts no orphaned-data warning is logged. Verified the test fails without the fix and passes with it.
- `yarn test`: 8 suites / 131 tests passed.
- `yarn lint` (eslint, constraints, prettier, depcheck/dedupe, changelog validate): clean.
- `yarn build`: verified `dist/extension-provider/createExternalExtensionProvider.{mjs,cjs}` contain the `ignoreStream` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to stream multiplex handling for a legacy substream; no RPC or auth behavior changes.
> 
> **Overview**
> Third-party extensions using **`createExternalExtensionProvider`** no longer get **`ObjectMultiplex - orphaned data for stream "publicConfig"`** warnings when MetaMask still pushes updates on the legacy **`publicConfig`** substream.
> 
> The multiplexer now calls **`ignoreStream('publicConfig')`** before the port pipeline is wired (same idea as the MetaMask contentscript). A unit test asserts that a **`publicConfig`** notification does not trigger that warning. **CHANGELOG** documents the fix under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a05e89f5e187ad5013e77687f8431ae46b1d8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->