### PR TITLE
chore: remove obsolete dist export entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING**: Remove obsolete `./dist/StreamProvider` and `./dist/initializeInpageProvider` export entries ([#430](https://github.com/MetaMask/providers/pull/430))
+  - Use the `./stream-provider` and `./initializeInpageProvider` exports instead.
+
 ## [22.1.1]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -29,26 +29,6 @@
         "default": "./dist/index.cjs"
       }
     },
-    "./dist/StreamProvider": {
-      "import": {
-        "types": "./dist/StreamProvider.d.mts",
-        "default": "./dist/StreamProvider.mjs"
-      },
-      "require": {
-        "types": "./dist/StreamProvider.d.cts",
-        "default": "./dist/StreamProvider.cjs"
-      }
-    },
-    "./dist/initializeInpageProvider": {
-      "import": {
-        "types": "./dist/initializeInpageProvider.d.mts",
-        "default": "./dist/initializeInpageProvider.mjs"
-      },
-      "require": {
-        "types": "./dist/initializeInpageProvider.d.cts",
-        "default": "./dist/initializeInpageProvider.cjs"
-      }
-    },
     "./initializeInpageProvider": {
       "import": {
         "types": "./dist/initializeInpageProvider.d.mts",


### PR DESCRIPTION
## Description

The `package.json` `exports` map contained obsolete `./dist/StreamProvider` and `./dist/initializeInpageProvider` entries. These are redundant with the canonical top-level subpath exports (`./stream-provider` and `./initializeInpageProvider`), which also have JavaScript redirect files (`stream-provider.js`, `initializeInpageProvider.js`) for build systems that don't support export maps, so they have strictly better support.

This PR removes the two `./dist/*` entries and keeps everything else unchanged. The legacy redirect files are unaffected since they use relative requires into `dist/`, which are not subject to the `exports` map.

Note for reviewers: consumers importing via the removed `./dist/*` subpaths will need to switch to `./stream-provider` / `./initializeInpageProvider`, so this may warrant a major version bump.

Fixes #393

## Testing

- `yarn build` — passes
- Spot-checked resolution with Node (CJS `require.resolve` and ESM `import.meta.resolve` via package self-reference):
  - `@metamask/providers`, `@metamask/providers/stream-provider`, `@metamask/providers/initializeInpageProvider`, and `@metamask/providers/package.json` all resolve correctly for both `require` and `import` conditions
  - `@metamask/providers/dist/StreamProvider` and `@metamask/providers/dist/initializeInpageProvider` now correctly fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`
- `yarn jest` — all 8 suites / 130 tests pass
- `yarn lint:eslint` and `yarn lint:misc --check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API surface for any consumer still on the `./dist/*` import paths; runtime behavior of supported exports is unchanged.
> 
> **Overview**
> **BREAKING:** Drops the redundant `package.json` export subpaths `@metamask/providers/dist/StreamProvider` and `@metamask/providers/dist/initializeInpageProvider`. Imports through those paths now fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
> 
> Consumers should use `@metamask/providers/stream-provider` and `@metamask/providers/initializeInpageProvider` instead; those entries and the root redirect files (`stream-provider.js`, `initializeInpageProvider.js`) are unchanged. The unreleased changelog records the removal under **Removed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e3064f2d93fb57b1666d6dc274ae1fa406913c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->